### PR TITLE
Build for both Python 2 and Python 3

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -22,6 +22,8 @@ samples/LowLevel/rand.py
 samples/LowLevel/test.py
 samples/LowLevel/test1.py
 PyKCS11/LowLevel.py
+PyKCS11/LowLevel.py2
+PyKCS11/LowLevel.py3
 PyKCS11/__init__.py
 src/ck_attribute_smart.cpp
 src/ck_attribute_smart.h
@@ -41,3 +43,5 @@ src/utility.cpp
 src/utility.h
 src/opensc/pkcs11.h
 src/pykcs11_wrap.cpp
+src/pykcs11_wrap.cpp-py2
+src/pykcs11_wrap.cpp-py3

--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,12 @@ src/pykcs11_wrap.cpp-py3: src/pykcs11.i
 src/pykcs11.i: src/opensc/pkcs11.h src/pkcs11lib.h src/pykcs11string.h src/ck_attribute_smart.h
 	touch $@
 
-dist: clean
+dist: src/pykcs11_wrap.cpp-py2 src/pykcs11_wrap.cpp-py3
+	$(MAKE) clean
 	$(PYTHON) setup.py sdist
 
-pypi: clean
+pypi: src/pykcs11_wrap.cpp-py2 src/pykcs11_wrap.cpp-py3
+	$(MAKE) clean
 	$(PYTHON) setup.py sdist upload
 
 doc: build

--- a/Makefile
+++ b/Makefile
@@ -16,13 +16,15 @@ build-stamp: src/pykcs11_wrap.cpp-py2 src/pykcs11_wrap.cpp-py3
 install: build
 	$(PYTHON) setup.py install --prefix=$(PREFIX) --root=$(DESTDIR)
 
-clean distclean:
+clean:
 	$(PYTHON) setup.py clean
-	rm -f src/pykcs11_wrap.cpp*
 	rm -rf build
-	rm -f *.pyc PyKCS11/*.pyc
-	rm -f PyKCS11/LowLevel.py*
+	find . -name '*.py[co]' -delete
 	rm -f build-stamp
+
+distclean: clean
+	rm -f PyKCS11/LowLevel.py*
+	rm -f src/pykcs11_wrap.cpp*
 
 rebuild: clean build
 

--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,12 @@ ifeq (, $(PYTHON))
 PYTHON=python
 endif
 PREFIX ?= $(shell $(PYTHON) -c 'import sys; print(sys.prefix)')
-IS_PYTHON_3 = $(shell $(PYTHON) -c 'import sys; print(sys.version_info[0] >= 3)')
-ifeq ($(IS_PYTHON_3), True)
-SWIG_OPTS := -py3
-endif
 
 build: build-stamp
 
-build-stamp: src/pykcs11_wrap.cpp
+build-stamp: src/pykcs11_wrap.cpp-py2 src/pykcs11_wrap.cpp-py3
+	cp src/pykcs11_wrap.cpp-py"`$(PYTHON) -c 'import sys; print(sys.version[0])'`" src/pykcs11_wrap.cpp
+	cp PyKCS11/LowLevel.py"`$(PYTHON) -c 'import sys; print(sys.version[0])'`" PyKCS11/LowLevel.py
 	$(PYTHON) setup.py build
 	touch build-stamp
 
@@ -20,16 +18,19 @@ install: build
 
 clean distclean:
 	$(PYTHON) setup.py clean
-	rm -f src/pykcs11_wrap.cpp
+	rm -f src/pykcs11_wrap.cpp*
 	rm -rf build
 	rm -f *.pyc PyKCS11/*.pyc
-	rm -f PyKCS11/LowLevel.py
+	rm -f PyKCS11/LowLevel.py*
 	rm -f build-stamp
 
 rebuild: clean build
 
-src/pykcs11_wrap.cpp: src/pykcs11.i
-	cd src ; swig -c++ -python $(SWIG_OPTS) pykcs11.i ; mv pykcs11_wrap.cxx pykcs11_wrap.cpp ; mv LowLevel.py ../PyKCS11
+src/pykcs11_wrap.cpp-py2: src/pykcs11.i
+	cd src ; swig -c++ -python -o pykcs11_wrap.cpp-py2 -outdir ../PyKCS11 pykcs11.i ; cd ../PyKCS11 ; mv LowLevel.py LowLevel.py2
+
+src/pykcs11_wrap.cpp-py3: src/pykcs11.i
+	cd src ; swig -c++ -python -py3 -o pykcs11_wrap.cpp-py3 pykcs11.i ; mv LowLevel.py ../PyKCS11/LowLevel.py3
 
 src/pykcs11.i: src/opensc/pkcs11.h src/pkcs11lib.h src/pykcs11string.h src/ck_attribute_smart.h
 	touch $@

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,6 @@ PREFIX ?= $(shell $(PYTHON) -c 'import sys; print(sys.prefix)')
 build: build-stamp
 
 build-stamp: src/pykcs11_wrap.cpp-py2 src/pykcs11_wrap.cpp-py3
-	cp src/pykcs11_wrap.cpp-py"`$(PYTHON) -c 'import sys; print(sys.version[0])'`" src/pykcs11_wrap.cpp
-	cp PyKCS11/LowLevel.py"`$(PYTHON) -c 'import sys; print(sys.version[0])'`" PyKCS11/LowLevel.py
 	$(PYTHON) setup.py build
 	touch build-stamp
 


### PR DESCRIPTION
Build pykcs11_wrap.cpp-py[23] and LowLevel.py[23] at the same time; use
one of the pair (2 or 3) to build PyKCS11 with the current python.