### PR TITLE
Fewer compiler warnings, show real readme.

### DIFF
--- a/.github/README.txt
+++ b/.github/README.txt
@@ -1,2 +1,0 @@
-github documentation:
-https://help.github.com/articles/helping-people-contribute-to-your-project/

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ if (platform.system().lower() == 'windows'):
     source_files.append("src/dyn_win32.c")
     source_files.append("pykcs11.rc")
     libraries_val = ["python%d%d" % pyver[:2]]
-    extra_compile_args = ["/Fdvc70.pdb", "/Zi", "/GR"]
+    extra_compile_args = ["/Fdvc70.pdb", "/Zi", "/GR", "/EHsc"]
     extra_link_args = ["/DEBUG", "/PDB:_LowLevel.pdb", "/SUBSYSTEM:WINDOWS", "/OPT:REF", "/OPT:ICF"]
 else:
     source_files.append("src/dyn_unix.c")

--- a/src/opensc/pkcs11.h
+++ b/src/opensc/pkcs11.h
@@ -707,7 +707,7 @@ struct ck_rsa_pkcs_oaep_params {
   unsigned long source_data_len;
 } ;
 
-typedef struct ck_rsa_pkcs_pss_params {
+struct ck_rsa_pkcs_pss_params {
   unsigned long hashAlg;
   unsigned long mgf;
   unsigned long sLen;


### PR DESCRIPTION
When I compiled this on my Windows machine, I was receiving several warnings about exceptions needing a compiler flag, and a malformed typedef. Both were small fixes.

For some reason, github prioritises the `.github/README.txt` over `README.md`. Deleting it shows the correct readme when you load the repo.