### PR TITLE
Add vendor errors to PyKCS11Error

### DIFF
--- a/PyKCS11/__init__.py
+++ b/PyKCS11/__init__.py
@@ -441,10 +441,15 @@ class PyKCS11Error(Exception):
         The text representation of a PKCS#11 error is something like:
         "CKR_DEVICE_ERROR (0x00000030)"
         """
-        if (self.value < 0):
-            return CKR[self.value] + " (%s)" % self.text
+        if (self.value in CKR):
+            if (self.value < 0):
+                return CKR[self.value] + " (%s)" % self.text
+            else:
+                return CKR[self.value] + " (0x%08X)" % self.value
+        elif (self.value & CKR_VENDOR_DEFINED):
+            return "Vendor error (0x%08X)" % (self.value & 0xffffffff & ~CKR_VENDOR_DEFINED)
         else:
-            return CKR[self.value] + " (0x%08X)" % self.value
+            return "Unknown error (0x%08X)" % self.value
 
 
 class PyKCS11Lib(object):


### PR DESCRIPTION
My token is returning some errors in the vendor block (bit 31 set). The current exception handler can't deal with it:

```
Traceback (most recent call last):
  File "test.py", line 23, in <module>
    session.login(pin, CKU_SO)
  File "C:\Python27\lib\site-packages\PyKCS11\__init__.py", line 903, in login
    raise PyKCS11Error(rv)
PyKCS11.PyKCS11Error: <exception str() failed>
```

By adding a check to test for vendor errors, the information is more meaningful:
```
...
  File "C:\Python27\lib\site-packages\PyKCS11\__init__.py", line 908, in login
    raise PyKCS11Error(rv)
PyKCS11.PyKCS11Error: Vendor error (0x01000001)
```

I've added a third branch in case a different error entirely is encountered, but I don't know if that would ever reasonably be returned.

The vendor error is &ed with 0xffffffff to give an unsigned value, as it was previously treating the value as negative which was quite confusing to read.