### PR TITLE
Support bytes for PIN in Py3

### DIFF
--- a/PyKCS11/__init__.py
+++ b/PyKCS11/__init__.py
@@ -441,10 +441,15 @@ class PyKCS11Error(Exception):
         The text representation of a PKCS#11 error is something like:
         "CKR_DEVICE_ERROR (0x00000030)"
         """
-        if (self.value < 0):
-            return CKR[self.value] + " (%s)" % self.text
+        if (self.value in CKR):
+            if (self.value < 0):
+                return CKR[self.value] + " (%s)" % self.text
+            else:
+                return CKR[self.value] + " (0x%08X)" % self.value
+        elif (self.value & CKR_VENDOR_DEFINED):
+            return "Vendor error (0x%08X)" % (self.value & 0xffffffff & ~CKR_VENDOR_DEFINED)
         else:
-            return CKR[self.value] + " (0x%08X)" % self.value
+            return "Unknown error (0x%08X)" % self.value
 
 
 class PyKCS11Lib(object):

--- a/src/pkcs11lib.cpp
+++ b/src/pkcs11lib.cpp
@@ -261,6 +261,17 @@ CK_RV CPKCS11Lib::C_Login(
 	return rv;
 }
 
+CK_RV CPKCS11Lib::C_Login(
+	CK_SESSION_HANDLE hSession,
+	CK_USER_TYPE userType,
+	vector<unsigned char> pin)
+{
+    CK_ULONG ulPinLen;
+    CK_BYTE* pPin = Vector2Buffer(pin, ulPinLen);
+	
+    return C_Login(hSession, userType, (char *)pPin, ulPinLen);
+}
+
 CK_RV CPKCS11Lib::C_Logout(
 	CK_SESSION_HANDLE hSession)
 {

--- a/src/pkcs11lib.h
+++ b/src/pkcs11lib.h
@@ -103,6 +103,10 @@ public:
 		CK_SESSION_HANDLE hSession,
 		unsigned long userType,
 		char* pPin, unsigned long ulPinLen);
+	CK_RV C_Login(
+		CK_SESSION_HANDLE hSession,
+		unsigned long userType,
+		vector<unsigned char> pin);
 #ifdef SWIG
 %clear (char* pPin, unsigned long ulPinLen),
 	(char* pOldPin, unsigned long ulOldLen),


### PR DESCRIPTION
I spent several fruitless hours trying to get SWIG's type checking/casting system to accept both strings and bytes, but couldn't wrangle it.

By simply overloading the Login method to support bytes, it works with either. I suppose if this is an acceptable workaround, I should also wrap InitToken, InitPIN and SetPIN?

Fixes #22