### PR TITLE
Derivekey support

### DIFF
--- a/PyKCS11/__init__.py
+++ b/PyKCS11/__init__.py
@@ -1544,23 +1544,6 @@ class Session(object):
             raise PyKCS11Error(rv)
         return ck_pub_handle, ck_prv_handle
 
-    def deriveKey(self, template, baseKey, mecha=MechanismAESGENERATEKEY):
-        """
-        derive a secret key
-
-        :param template: template for the secret key
-        :param mecha: mechanism to use
-        :return: handle of the derived key
-        :rtype: PyKCS11.LowLevel.CK_OBJECT_HANDLE
-        """
-        t = self._template2ckattrlist(template)
-        ck_handle = PyKCS11.LowLevel.CK_OBJECT_HANDLE()
-        m = mecha.to_native()
-        rv = self.lib.C_DeriveKey(self.session, m, baseKey, t, ck_handle)
-        if rv != CKR_OK:
-            raise PyKCS11Error(rv)
-        return ck_handle
-
     def findObjects(self, template=()):
         """
         find the objects matching the template pattern

--- a/PyKCS11/__init__.py
+++ b/PyKCS11/__init__.py
@@ -771,6 +771,88 @@ class AES_GCM_Mechanism(object):
     def to_native(self):
         return self._mech
 
+class DUKPT_DERIVE_DATAKEY_Mechanism(object):
+    """CKM_DES2_DUKPT_DATA warpping mechanisms"""
+
+    def __init__(self, ksn):
+        """
+        :param ksn: Key Sequence Number
+        """
+        self._param = PyKCS11.LowLevel.CK_KEY_DERIVATION_STRING_DATA()
+
+        self._source_ksn = ckbytelist(ksn)
+        self._param.pData = self._source_ksn
+        self._param.ulLen = len(self._source_ksn)
+
+        self._mech = PyKCS11.LowLevel.CK_MECHANISM()
+        self._mech.mechanism = CKM_DES2_DUKPT_DATA
+        self._mech.pParameter = self._param
+        self._mech.ulParameterLen = PyKCS11.LowLevel.CK_KEY_DERIVATION_STRING_DATA_LENGTH
+
+    def to_native(self):
+        return self._mech
+
+class DUKPT_DERIVE_MACKEY_Mechanism(object):
+    """CKM_DES2_DUKPT_MAC warpping mechanisms"""
+
+    def __init__(self, ksn):
+        """
+        :param ksn: Key Sequence Number
+        """
+        self._param = PyKCS11.LowLevel.CK_KEY_DERIVATION_STRING_DATA()
+
+        self._source_ksn = ckbytelist(ksn)
+        self._param.pData = self._source_ksn
+        self._param.ulLen = len(self._source_ksn)
+
+        self._mech = PyKCS11.LowLevel.CK_MECHANISM()
+        self._mech.mechanism = CKM_DES2_DUKPT_MAC
+        self._mech.pParameter = self._param
+        self._mech.ulParameterLen = PyKCS11.LowLevel.CK_KEY_DERIVATION_STRING_DATA_LENGTH
+
+    def to_native(self):
+        return self._mech
+
+class ECIES_Mechanism(object):
+    """CKM_ECIES warpping mechanism"""
+
+    def __init__(self, dhPrimitive, kdf, sharedData1, sharedData2, encScheme, encKeyLenInBits, macScheme, macKeyLenInBits, macLenInBits):
+        """
+        :param dhPrimitive: This is the Diffie-Hellman primitive used to derive the shared secret value. Valid value -> CKDHP_STANDARD 
+        :param kdf: This is the key derivation function used on the shared secret value. Valid value -> CKD_SHA1_KDF 
+        :param sharedData1: This is the key derivation padding data shared between the two parties
+        :param sharedData2: This is the MAC padding data shared between the two parties
+        :param encScheme: This is the encryption scheme used to transform the input data. Valid value -> CKES_XOR 
+        :param encKeyLenInBits: This is the bit length of the key to use for the encryption scheme
+        :param macScheme: This is the MAC scheme used for MAC generation or validation. Valid values -> CKMS_HMAC_SHA1, CKMS_SHA1 
+        :param macKeyLenInBits: This is the bit length of the key to use for the MAC scheme
+        :param macLenInBits: This is the bit length of the MAC scheme output
+        """
+        self._param = PyKCS11.LowLevel.CK_ECIES_PARAMS()
+
+        self._source_sharedData1 = ckbytelist(sharedData1)
+        self._param.pSharedData1 = self._source_sharedData1
+        self._param.ulSharedDataLen1 = len(self._source_sharedData1)
+
+        self._source_sharedData2 = ckbytelist(sharedData2)
+        self._param.pSharedData2 = self._source_sharedData2
+        self._param.ulSharedDataLen2 = len(self._source_sharedData2)
+
+        self._param.dhPrimitive = dhPrimitive
+        self._param.kdf = kdf
+        self._param.encScheme = encScheme
+        self._param.ulEncKeyLenInBits = encKeyLenInBits
+        self._param.macScheme = macScheme
+        self._param.ulMacKeyLenInBits = macKeyLenInBits
+        self._param.ulMacLenInBits = macLenInBits
+
+        self._mech = PyKCS11.LowLevel.CK_MECHANISM()
+        self._mech.mechanism = CKM_ECIES
+        self._mech.pParameter = self._param
+        self._mech.ulParameterLen = PyKCS11.LowLevel.CK_ECIES_PARAMS_LENGTH
+
+    def to_native(self):
+        return self._mech
 
 class RSAOAEPMechanism(object):
     """RSA OAEP Wrapping mechanism"""
@@ -1405,6 +1487,23 @@ class Session(object):
         if rv != CKR_OK:
             raise PyKCS11Error(rv)
         return ck_pub_handle, ck_prv_handle
+
+    def deriveKey(self, template, baseKey, mecha=MechanismAESGENERATEKEY):
+        """
+        derive a secret key
+
+        :param template: template for the secret key
+        :param mecha: mechanism to use
+        :return: handle of the derived key
+        :rtype: PyKCS11.LowLevel.CK_OBJECT_HANDLE
+        """
+        t = self._template2ckattrlist(template)
+        ck_handle = PyKCS11.LowLevel.CK_OBJECT_HANDLE()
+        m = mecha.to_native()
+        rv = self.lib.C_DeriveKey(self.session, m, baseKey, t, ck_handle)
+        if rv != CKR_OK:
+            raise PyKCS11Error(rv)
+        return ck_handle
 
     def findObjects(self, template=()):
         """

--- a/PyKCS11/__init__.py
+++ b/PyKCS11/__init__.py
@@ -31,6 +31,7 @@ CK_INVALID_HANDLE = PyKCS11.LowLevel.CK_INVALID_HANDLE
 
 CKA = {}
 CKC = {}
+CKD = {}
 CKF = {}
 CKG = {}
 CKH = {}
@@ -46,6 +47,7 @@ CKZ = {}
 for x in PyKCS11.LowLevel.__dict__.keys():
     if x[:4] == 'CKA_' \
       or x[:4] == 'CKC_' \
+      or x[:4] == 'CKD_' \
       or x[:4] == 'CKF_' \
       or x[:4] == 'CKG_' \
       or x[:4] == 'CKH_' \
@@ -909,6 +911,38 @@ class RSA_PSS_Mechanism(object):
     def to_native(self):
         return self._mech
 
+class ECDH1_DERIVE_Mechanism(object):
+    """CKM_ECDH1_DERIVE key derivation mechanism"""
+
+    def __init__(self, kdf, sharedData, publicData):
+        """
+        :param kdf: Key derivation function
+        :param sharedData: additional shared data
+        :param publicData: Other party public key (encoded uncompressed or concatenated x and y coordinates)
+        """
+        self._param = PyKCS11.LowLevel.CK_ECDH1_DERIVE_PARAMS()
+
+        self._param.kdf = kdf
+
+        if sharedData:
+            self._shared_data = ckbytelist(sharedData)
+            self._param.pSharedData = self._shared_data
+            self._param.ulSharedDataLen = len(self._shared_data)
+        else:
+            self._source_shared_data = None
+
+        self._public_data = ckbytelist(publicData)
+        self._param.pPublicData = self._public_data
+        self._param.ulPublicDataLen = len(self._public_data)
+
+        self._mech = PyKCS11.LowLevel.CK_MECHANISM()
+        self._mech.mechanism = CKM_ECDH1_DERIVE
+        self._mech.pParameter = self._param
+        self._mech.ulParameterLen = PyKCS11.LowLevel.CK_ECDH1_DERIVE_PARAMS_LENGTH
+
+    def to_native(self):
+        return self._mech
+
 
 class DigestSession(object):
     def __init__(self, lib, session, mecha):
@@ -1333,6 +1367,28 @@ class Session(object):
         attrs = self._template2ckattrlist(template)
         rv = self.lib.C_UnwrapKey(self.session, m, unwrappingKey,
                                   data1, attrs, handle)
+        if rv != CKR_OK:
+            raise PyKCS11Error(rv)
+        return handle
+
+    def deriveKey(self, baseKey, template, mecha):
+        """
+        C_DeriveKey
+
+        :param baseKey: the base key handle
+        :type baseKey: integer
+        :param template: template for the unwrapped key
+        :param mecha: the decrypt mechanism to be used (use
+          `ECDH1_DERIVE_Mechanism(...)` for `CKM_ECDH1_DERIVE`)
+        :type mecha: :class:`Mechanism`
+        :return: the unwrapped key object
+        :rtype: integer
+
+        """
+        m = mecha.to_native()
+        handle = PyKCS11.LowLevel.CK_OBJECT_HANDLE()
+        attrs = self._template2ckattrlist(template)
+        rv = self.lib.C_DeriveKey(self.session, m, baseKey, attrs, handle)
         if rv != CKR_OK:
             raise PyKCS11Error(rv)
         return handle

--- a/src/opensc/pkcs11.h
+++ b/src/opensc/pkcs11.h
@@ -722,6 +722,25 @@ struct ck_gcm_params {
   unsigned long ulTagBits;
 } ;
 
+struct ck_key_derivation_string_data {
+	void * pData;
+	unsigned long ulLen;
+} ;
+
+struct ck_ecies_params {
+	unsigned long dhPrimitive;
+    unsigned long kdf;
+    unsigned long ulSharedDataLen1;
+    void * pSharedData1;
+    unsigned long encScheme;
+    unsigned long ulEncKeyLenInBits;
+    unsigned long macScheme;
+    unsigned long ulMacKeyLenInBits;
+    unsigned long ulMacLenInBits;
+    unsigned long ulSharedDataLen2;
+    void * pSharedData2;
+} ;
+
 #define CKF_HW			(1 << 0)
 #define CKF_ENCRYPT		(1 << 8)
 #define CKF_DECRYPT		(1 << 9)
@@ -1292,6 +1311,10 @@ typedef struct ck_rsa_pkcs_pss_params CK_RSA_PKCS_PSS_PARAMS;
 typedef struct ck_rsa_pkcs_pss_params *CK_RSA_PKCS_PSS_PARAMS_PTR;
 
 typedef struct ck_gcm_params CK_GCM_PARAMS;
+
+typedef struct ck_key_derivation_string_data CK_KEY_DERIVATION_STRING_DATA;
+
+typedef struct ck_ecies_params CK_ECIES_PARAMS;
 
 typedef struct ck_function_list CK_FUNCTION_LIST;
 typedef struct ck_function_list *CK_FUNCTION_LIST_PTR;

--- a/src/opensc/pkcs11.h
+++ b/src/opensc/pkcs11.h
@@ -166,6 +166,8 @@ extern "C" {
 #define source_data pSourceData
 #define source_data_len ulSourceDataLen
 
+#define ck_ecdh1_derive_params CK_ECDH1_DERIVE_PARAMS
+
 #define ck_rv_t CK_RV
 #define ck_notify_t CK_NOTIFY
 
@@ -682,6 +684,11 @@ typedef unsigned long ck_mechanism_type_t;
 #define CKG_MGF1_SHA384  (0x00000003)
 #define CKG_MGF1_SHA512  (0x00000004)
 
+#define CKD_NULL                 (0x00000001)
+#define CKD_SHA1_KDF             (0x00000002)
+#define CKD_SHA1_KDF_ASN1        (0x00000003)
+#define CKD_SHA1_KDF_CONCATENATE (0x00000004)
+
 
 struct ck_mechanism
 {
@@ -740,6 +747,14 @@ struct ck_ecies_params {
     unsigned long ulSharedDataLen2;
     void * pSharedData2;
 } ;
+struct ck_ecdh1_derive_params {
+  unsigned long kdf;
+  unsigned long ulSharedDataLen;
+  void * pSharedData;
+  unsigned long ulPublicDataLen;
+  void * pPublicData;
+} ;
+
 
 #define CKF_HW			(1 << 0)
 #define CKF_ENCRYPT		(1 << 8)

--- a/src/pkcs11lib.cpp
+++ b/src/pkcs11lib.cpp
@@ -861,29 +861,6 @@ CK_RV CPKCS11Lib::C_GenerateKeyPair(
 	return rv;
 }
 
-CK_RV CPKCS11Lib::C_DeriveKey(
-	CK_SESSION_HANDLE hSession,
-	CK_MECHANISM* pMechanism,
-	CK_OBJECT_HANDLE hBaseKey,
-	vector<CK_ATTRIBUTE_SMART> DeriveKeyTemplate,
-	CK_OBJECT_HANDLE& outhKey)
-{
-	CPKCS11LIB_PROLOGUE(C_DeriveKey);
-	CK_ULONG ulDeriveKeyAttributeCount = 0;
-	CK_OBJECT_HANDLE hKey = static_cast<CK_OBJECT_HANDLE>(outhKey);
-	CK_ATTRIBUTE * pDeriveKeyTemplate = AttrVector2Template(DeriveKeyTemplate,
-		ulDeriveKeyAttributeCount);
-
-	rv = m_pFunc->C_DeriveKey(hSession, pMechanism, hBaseKey,
-		pDeriveKeyTemplate, ulDeriveKeyAttributeCount,
-		&hKey);
-	if (pDeriveKeyTemplate)
-		DestroyTemplate(pDeriveKeyTemplate, ulDeriveKeyAttributeCount);
-	outhKey = static_cast<CK_OBJECT_HANDLE>(hKey);
-	CPKCS11LIB_EPILOGUE;
-	return rv;
-}
-
 CK_RV CPKCS11Lib::C_WrapKey(
 	CK_SESSION_HANDLE hSession,
 	CK_MECHANISM* pMechanism,

--- a/src/pkcs11lib.cpp
+++ b/src/pkcs11lib.cpp
@@ -943,6 +943,34 @@ CK_RV CPKCS11Lib::C_UnwrapKey(
 	return rv;
 }
 
+
+CK_RV CPKCS11Lib::C_DeriveKey(
+		CK_SESSION_HANDLE hSession,
+		CK_MECHANISM *pMechanism,
+		CK_OBJECT_HANDLE hBaseKey,
+		vector<CK_ATTRIBUTE_SMART> Template,
+		CK_OBJECT_HANDLE & outKey)
+{
+	CPKCS11LIB_PROLOGUE(C_DeriveKey);
+	CK_OBJECT_HANDLE hKey = static_cast<CK_OBJECT_HANDLE>(outKey);
+
+	CK_ULONG ulAttributeCount = 0;
+	CK_ATTRIBUTE* pTemplate = AttrVector2Template(Template, ulAttributeCount);
+
+	rv = m_pFunc->C_DeriveKey(hSession,
+		pMechanism,
+		hBaseKey,
+		pTemplate,
+		ulAttributeCount,
+		&hKey);
+
+	if (pTemplate)
+		DestroyTemplate(pTemplate, ulAttributeCount);
+	outKey = static_cast<CK_OBJECT_HANDLE>(hKey);
+	CPKCS11LIB_EPILOGUE;
+	return rv;
+}
+
 CK_RV CPKCS11Lib::C_SeedRandom(
 	CK_SESSION_HANDLE hSession,
 	vector<unsigned char> Seed)

--- a/src/pkcs11lib.cpp
+++ b/src/pkcs11lib.cpp
@@ -861,6 +861,29 @@ CK_RV CPKCS11Lib::C_GenerateKeyPair(
 	return rv;
 }
 
+CK_RV CPKCS11Lib::C_DeriveKey(
+	CK_SESSION_HANDLE hSession,
+	CK_MECHANISM* pMechanism,
+	CK_OBJECT_HANDLE hBaseKey,
+	vector<CK_ATTRIBUTE_SMART> DeriveKeyTemplate,
+	CK_OBJECT_HANDLE& outhKey)
+{
+	CPKCS11LIB_PROLOGUE(C_DeriveKey);
+	CK_ULONG ulDeriveKeyAttributeCount = 0;
+	CK_OBJECT_HANDLE hKey = static_cast<CK_OBJECT_HANDLE>(outhKey);
+	CK_ATTRIBUTE * pDeriveKeyTemplate = AttrVector2Template(DeriveKeyTemplate,
+		ulDeriveKeyAttributeCount);
+
+	rv = m_pFunc->C_DeriveKey(hSession, pMechanism, hBaseKey,
+		pDeriveKeyTemplate, ulDeriveKeyAttributeCount,
+		&hKey);
+	if (pDeriveKeyTemplate)
+		DestroyTemplate(pDeriveKeyTemplate, ulDeriveKeyAttributeCount);
+	outhKey = static_cast<CK_OBJECT_HANDLE>(hKey);
+	CPKCS11LIB_EPILOGUE;
+	return rv;
+}
+
 CK_RV CPKCS11Lib::C_WrapKey(
 	CK_SESSION_HANDLE hSession,
 	CK_MECHANISM* pMechanism,

--- a/src/pkcs11lib.h
+++ b/src/pkcs11lib.h
@@ -273,6 +273,13 @@ public:
 		vector<CK_ATTRIBUTE_SMART> Template,
 		CK_OBJECT_HANDLE & outhKey);
 
+	CK_RV C_DeriveKey(
+			CK_SESSION_HANDLE hSession,
+			CK_MECHANISM *pMechanism,
+			CK_OBJECT_HANDLE hBaseKey,
+			vector<CK_ATTRIBUTE_SMART> Template,
+			CK_OBJECT_HANDLE & outkey);
+
 	CK_RV C_SeedRandom(
 		CK_SESSION_HANDLE hSession,
 		vector<unsigned char> Seed);

--- a/src/pkcs11lib.h
+++ b/src/pkcs11lib.h
@@ -251,6 +251,13 @@ public:
 		CK_OBJECT_HANDLE& outhPublicKey,
 		CK_OBJECT_HANDLE& outhPrivateKey );
 
+	CK_RV C_DeriveKey(
+		CK_SESSION_HANDLE hSession,
+		CK_MECHANISM* pMechanism,
+		CK_OBJECT_HANDLE hBaseKey,
+		vector<CK_ATTRIBUTE_SMART> DeriveKeyTemplate,
+		CK_OBJECT_HANDLE& outhKey );
+
 	CK_RV C_WrapKey(
 		CK_SESSION_HANDLE hSession,
 		CK_MECHANISM* pMechanism,

--- a/src/pkcs11lib.h
+++ b/src/pkcs11lib.h
@@ -251,13 +251,6 @@ public:
 		CK_OBJECT_HANDLE& outhPublicKey,
 		CK_OBJECT_HANDLE& outhPrivateKey );
 
-	CK_RV C_DeriveKey(
-		CK_SESSION_HANDLE hSession,
-		CK_MECHANISM* pMechanism,
-		CK_OBJECT_HANDLE hBaseKey,
-		vector<CK_ATTRIBUTE_SMART> DeriveKeyTemplate,
-		CK_OBJECT_HANDLE& outhKey );
-
 	CK_RV C_WrapKey(
 		CK_SESSION_HANDLE hSession,
 		CK_MECHANISM* pMechanism,

--- a/src/pykcs11.i
+++ b/src/pykcs11.i
@@ -251,12 +251,14 @@ typedef struct CK_DATE{
           if (!SWIG_IsOK(res2)) {
             res2 = SWIG_ConvertPtr($input, &arg2, $descriptor(CK_GCM_PARAMS*), 0);
             if (!SWIG_IsOK(res2)) {
-			  res2 = SWIG_ConvertPtr($input, &arg2, $descriptor(CK_KEY_DERIVATION_STRING_DATA*), 0);
-			  if (!SWIG_IsOK(res2)) {
-			    res2 = SWIG_ConvertPtr($input, &arg2, $descriptor(CK_ECIES_PARAMS*), 0);
-				if (!SWIG_IsOK(res2)) {
-                  SWIG_exception_fail(SWIG_ArgError(res2), "unsupported CK_MECHANISM Parameter type.");
-				}
+              res2 = SWIG_ConvertPtr($input, &arg2, $descriptor(CK_ECDH1_DERIVE_PARAMS*), 0);
+              if (!SWIG_IsOK(res2)) {
+                res2 = SWIG_ConvertPtr($input, &arg2, $descriptor(CK_KEY_DERIVATION_STRING_DATA*), 0);
+			    if (!SWIG_IsOK(res2)) {
+			      res2 = SWIG_ConvertPtr($input, &arg2, $descriptor(CK_ECIES_PARAMS*), 0);
+			      if (!SWIG_IsOK(res2)) {
+                    SWIG_exception_fail(SWIG_ArgError(res2), "unsupported CK_MECHANISM Parameter type.");
+			      }
 			  }
             }
           }
@@ -403,6 +405,35 @@ typedef struct CK_RSA_PKCS_PSS_PARAMS {
 };
 
 %constant int CK_RSA_PKCS_PSS_PARAMS_LENGTH = sizeof(CK_RSA_PKCS_PSS_PARAMS);
+
+//%typemap(in) void*;
+//%typemap(in) void* = char*;
+
+typedef struct CK_ECDH1_DERIVE_PARAMS {
+	unsigned long kdf;
+	unsigned long ulSharedDataLen;
+	void* pSharedData;
+	unsigned long ulPublicDataLen;
+	void* pPublicData;
+} CK_ECDH1_DERIVE_PARAMS;
+
+%extend CK_ECDH1_DERIVE_PARAMS
+{
+	CK_ECDH1_DERIVE_PARAMS()
+	{
+		CK_ECDH1_DERIVE_PARAMS *p = new CK_ECDH1_DERIVE_PARAMS();
+		p->kdf = CKD_NULL;
+		p->pSharedData = NULL;
+		p->ulSharedDataLen = 0;
+		p->pPublicData = NULL;
+		p->ulPublicDataLen = 0;
+
+		return p;
+	}
+};
+
+%constant int CK_ECDH1_DERIVE_PARAMS_LENGTH = sizeof(CK_ECDH1_DERIVE_PARAMS);
+
 
 typedef struct CK_MECHANISM_INFO {
 %immutable;

--- a/src/pykcs11.i
+++ b/src/pykcs11.i
@@ -385,9 +385,6 @@ typedef struct CK_ECIES_PARAMS {
 
 %constant int CK_ECIES_PARAMS_LENGTH = sizeof(CK_ECIES_PARAMS);
 
-// %typemap(in) void*;
-// %typemap(in) void* = char*;
-
 typedef struct CK_RSA_PKCS_OAEP_PARAMS {
   unsigned long hashAlg;
   unsigned long mgf;

--- a/src/pykcs11.i
+++ b/src/pykcs11.i
@@ -251,7 +251,13 @@ typedef struct CK_DATE{
           if (!SWIG_IsOK(res2)) {
             res2 = SWIG_ConvertPtr($input, &arg2, $descriptor(CK_GCM_PARAMS*), 0);
             if (!SWIG_IsOK(res2)) {
-              SWIG_exception_fail(SWIG_ArgError(res2), "unsupported CK_MECHANISM Parameter type.");
+			  res2 = SWIG_ConvertPtr($input, &arg2, $descriptor(CK_KEY_DERIVATION_STRING_DATA*), 0);
+			  if (!SWIG_IsOK(res2)) {
+			    res2 = SWIG_ConvertPtr($input, &arg2, $descriptor(CK_ECIES_PARAMS*), 0);
+				if (!SWIG_IsOK(res2)) {
+                  SWIG_exception_fail(SWIG_ArgError(res2), "unsupported CK_MECHANISM Parameter type.");
+				}
+			  }
             }
           }
       }
@@ -294,6 +300,59 @@ typedef struct CK_GCM_PARAMS {
 };
 
 %constant int CK_GCM_PARAMS_LENGTH = sizeof(CK_GCM_PARAMS);
+
+typedef struct CK_KEY_DERIVATION_STRING_DATA {
+	void * pData;
+	unsigned long ulLen;
+} CK_KEY_DERIVATION_STRING_DATA;
+
+%extend CK_KEY_DERIVATION_STRING_DATA
+{
+    CK_KEY_DERIVATION_STRING_DATA()
+    {
+        CK_KEY_DERIVATION_STRING_DATA *p = new CK_KEY_DERIVATION_STRING_DATA();
+        p->pData = NULL;
+        p->ulLen = 0;
+        return p;
+    }
+};
+
+%constant int CK_KEY_DERIVATION_STRING_DATA_LENGTH = sizeof(CK_KEY_DERIVATION_STRING_DATA);
+
+typedef struct CK_ECIES_PARAMS {
+	unsigned long dhPrimitive;
+    unsigned long kdf;
+    unsigned long ulSharedDataLen1;
+    void * pSharedData1;
+    unsigned long encScheme;
+    unsigned long ulEncKeyLenInBits;
+    unsigned long macScheme;
+    unsigned long ulMacKeyLenInBits;
+    unsigned long ulMacLenInBits;
+    unsigned long ulSharedDataLen2;
+    void * pSharedData2;
+} CK_ECIES_PARAMS;
+
+%extend CK_ECIES_PARAMS
+{
+    CK_ECIES_PARAMS()
+    {
+        CK_ECIES_PARAMS *p = new CK_ECIES_PARAMS();
+        p->pSharedData1 = p->pSharedData2 = NULL;
+        p->dhPrimitive = 0;
+		p->kdf = 0;
+		p->ulSharedDataLen1 = 0;
+		p->encScheme = 0;
+		p->ulEncKeyLenInBits = 0;
+		p->macScheme = 0;
+		p->ulMacKeyLenInBits = 0;
+		p->ulMacLenInBits = 0;
+		p->ulSharedDataLen2 = 0;
+        return p;
+    }
+};
+
+%constant int CK_ECIES_PARAMS_LENGTH = sizeof(CK_ECIES_PARAMS);
 
 %typemap(in) void*;
 %typemap(in) void* = char*;
@@ -1023,6 +1082,9 @@ typedef unsigned long CK_RV;
 #define CKM_HKDF_DATA                  0x0000402b
 #define CKM_HKDF_KEY_GEN               0x0000402c
 #define CKM_VENDOR_DEFINED             0x80000000UL
+#define CKM_DES2_DUKPT_MAC             (CKM_VENDOR_DEFINED + 0x612)
+#define CKM_DES2_DUKPT_DATA            (CKM_VENDOR_DEFINED + 0x614)
+#define CKM_ECIES                      (CKM_VENDOR_DEFINED + 0xa00)
 
 #define CKG_MGF1_SHA1    0x00000001
 #define CKG_MGF1_SHA256  0x00000002
@@ -1190,6 +1252,13 @@ typedef unsigned long CK_RV;
 #define CKD_BLAKE2B_256_KDF      0x00000018
 #define CKD_BLAKE2B_384_KDF      0x00000019
 #define CKD_BLAKE2B_512_KDF      0x0000001a
+
+#define CKDHP_STANDARD           0x00000001
+
+#define CKES_XOR                 0x00000001
+
+#define CKMS_HMAC_SHA1	         0x00000001
+#define CKMS_SHA1		         0x00000002
 
 #define CKP_PKCS5_PBKD2_HMAC_SHA1 0x00000001
 #define CKP_PKCS5_PBKD2_HMAC_GOSTR3411     0x00000002

--- a/src/pykcs11.i
+++ b/src/pykcs11.i
@@ -240,7 +240,12 @@ typedef struct CK_DATE{
         // The recommanded code in C++11 should be vect->data() but
         // Microsoft Visual Studio 9.0 does not suport it and this
         // compiler is needed for Python 2.7
-        arg2 = &vect->operator[](0);
+
+        // Only set value if not null
+        if (vect)
+            arg2 = &vect->operator[](0);
+        else
+            arg2 = NULL;
     }
     else
     {
@@ -259,6 +264,7 @@ typedef struct CK_DATE{
 			      if (!SWIG_IsOK(res2)) {
                     SWIG_exception_fail(SWIG_ArgError(res2), "unsupported CK_MECHANISM Parameter type.");
 			      }
+                }
 			  }
             }
           }
@@ -281,6 +287,29 @@ typedef struct CK_MECHANISM {
 		return m;
 	}
 };
+
+// For all complex mechanism parameters which has 'void *' as a member, it must a ckbytelist
+%typemap(in) void* {
+    vector<unsigned char> *vect;
+    int res = SWIG_ConvertPtr($input, (void **)&vect, SWIGTYPE_p_std__vectorT_unsigned_char_std__allocatorT_unsigned_char_t_t, 0);
+    if (SWIG_IsOK(res))
+    {
+        // Get the data from the vector
+        // The recommanded code in C++11 should be vect->data() but
+        // Microsoft Visual Studio 9.0 does not suport it and this
+        // compiler is needed for Python 2.7
+
+        // Only set value if not null
+        if (vect)
+            arg2 = &vect->operator[](0);
+        else
+            arg2 = NULL;
+    }
+    else
+    {
+        SWIG_exception_fail(SWIG_ArgError(res), "void * members of CK_* mechanism params must be represented as ckbytelist type");
+    }
+}
 
 typedef struct CK_GCM_PARAMS {
     void * pIv;
@@ -356,8 +385,8 @@ typedef struct CK_ECIES_PARAMS {
 
 %constant int CK_ECIES_PARAMS_LENGTH = sizeof(CK_ECIES_PARAMS);
 
-%typemap(in) void*;
-%typemap(in) void* = char*;
+// %typemap(in) void*;
+// %typemap(in) void* = char*;
 
 typedef struct CK_RSA_PKCS_OAEP_PARAMS {
   unsigned long hashAlg;
@@ -383,9 +412,6 @@ typedef struct CK_RSA_PKCS_OAEP_PARAMS {
 
 %constant int CK_RSA_PKCS_OAEP_PARAMS_LENGTH = sizeof(CK_RSA_PKCS_OAEP_PARAMS);
 
-%typemap(in) void*;
-%typemap(in) void* = char*;
-
 typedef struct CK_RSA_PKCS_PSS_PARAMS {
     unsigned long hashAlg;
     unsigned long mgf;
@@ -405,9 +431,6 @@ typedef struct CK_RSA_PKCS_PSS_PARAMS {
 };
 
 %constant int CK_RSA_PKCS_PSS_PARAMS_LENGTH = sizeof(CK_RSA_PKCS_PSS_PARAMS);
-
-%typemap(in) void*;
-%typemap(in) void* = char*;
 
 typedef struct CK_ECDH1_DERIVE_PARAMS {
 	unsigned long kdf;

--- a/src/pykcs11.i
+++ b/src/pykcs11.i
@@ -383,8 +383,8 @@ typedef struct CK_RSA_PKCS_OAEP_PARAMS {
 
 %constant int CK_RSA_PKCS_OAEP_PARAMS_LENGTH = sizeof(CK_RSA_PKCS_OAEP_PARAMS);
 
-//%typemap(in) void*;
-//%typemap(in) void* = char*;
+%typemap(in) void*;
+%typemap(in) void* = char*;
 
 typedef struct CK_RSA_PKCS_PSS_PARAMS {
     unsigned long hashAlg;
@@ -406,8 +406,8 @@ typedef struct CK_RSA_PKCS_PSS_PARAMS {
 
 %constant int CK_RSA_PKCS_PSS_PARAMS_LENGTH = sizeof(CK_RSA_PKCS_PSS_PARAMS);
 
-//%typemap(in) void*;
-//%typemap(in) void* = char*;
+%typemap(in) void*;
+%typemap(in) void* = char*;
 
 typedef struct CK_ECDH1_DERIVE_PARAMS {
 	unsigned long kdf;

--- a/test/test_asymetric.py
+++ b/test/test_asymetric.py
@@ -168,7 +168,7 @@ class TestUtil(unittest.TestCase):
         cipherText = self.session.encrypt(self.pubKey, plainText, mech)
         decrypted = self.session.decrypt(self.privKey, cipherText, mech)
 
-        text = "".join(map(chr, decrypted))
+        text = bytes(decrypted).decode("utf-8")
 
         self.assertEqual(text, plainText)
 

--- a/test/test_asymetric.py
+++ b/test/test_asymetric.py
@@ -8,7 +8,9 @@ class TestUtil(unittest.TestCase):
         self.pkcs11.load()
 
         # get SoftHSM major version
-        self.SoftHSMversion = self.pkcs11.getInfo().libraryVersion[0]
+        info = self.pkcs11.getInfo()
+        self.SoftHSMversion = info.libraryVersion[0]
+        self.manufacturer = info.manufacturerID
 
         self.slot = self.pkcs11.getSlotList(tokenPresent=True)[0]
         self.session = self.pkcs11.openSession(
@@ -144,6 +146,25 @@ class TestUtil(unittest.TestCase):
         plainText = "A test string"
 
         mech = PyKCS11.RSAOAEPMechanism(PyKCS11.CKM_SHA_1, PyKCS11.CKG_MGF1_SHA1)
+        cipherText = self.session.encrypt(self.pubKey, plainText, mech)
+        decrypted = self.session.decrypt(self.privKey, cipherText, mech)
+
+        text = "".join(map(chr, decrypted))
+
+        self.assertEqual(text, plainText)
+
+    def test_RSA_OAEPwithAAD(self):
+        if self.SoftHSMversion < 2:
+            self.skipTest("RSA OAEP only supported by SoftHSM >= 2")
+
+        if self.manufacturer.startswith("SoftHSM"):
+            self.skipTest("SoftHSMv2 returns CKR_ARGUMENTS_BAD. 'AAD' not in expected format or unsupported.")
+
+        # RSA OAEP
+        plainText = "A test string"
+
+        aad = "sample aad".encode("utf-8")
+        mech = PyKCS11.RSAOAEPMechanism(PyKCS11.CKM_SHA_1, PyKCS11.CKG_MGF1_SHA1, aad)
         cipherText = self.session.encrypt(self.pubKey, plainText, mech)
         decrypted = self.session.decrypt(self.privKey, cipherText, mech)
 

--- a/test/test_derive.py
+++ b/test/test_derive.py
@@ -60,6 +60,7 @@ class TestUtil(unittest.TestCase):
         # Known base symmetric key
         knownAESKeyValue = bytes([0xAA, 0xAA, 0xAA, 0xAA, 0xBB, 0xBB, 0xBB, 0xBB,
                                         0xCC, 0xCC, 0xCC, 0xCC, 0xDD, 0xDD, 0xDD, 0xDD])
+        knownAESKeyCheckValue = (0x9E, 0xCE, 0xA2)
 
         keyID = (0x11,)
         wrapKeyTemplate = [
@@ -100,6 +101,8 @@ class TestUtil(unittest.TestCase):
         ]
         self.baseAESKey = self.session.unwrapKey(AESKey, wrappedKey, baseAESKeyTemplate, mechanism)
         self.assertIsNotNone(self.baseAESKey)
+        checkValue = self.session.encrypt(self.baseAESKey, [0] * 16, mechanism)
+        self.assertSequenceEqual(knownAESKeyCheckValue, checkValue[0:3]) # ZL6
         self.session.destroyObject(AESKey)
 
     def tearDown(self):
@@ -113,7 +116,7 @@ class TestUtil(unittest.TestCase):
 
     def test_deriveKey_ECDH1_DERIVE(self):
         if self.SoftHSMversion < 2:
-            self.skipTest("generateKey() only supported by SoftHSM >= 2")
+            self.skipTest("generateKeyPair() only supported by SoftHSM >= 2")
 
         keyID = (0x22,)
         pubTemplate = [

--- a/test/test_derive.py
+++ b/test/test_derive.py
@@ -1,0 +1,238 @@
+import unittest
+from asn1crypto.keys import ECDomainParameters, NamedCurve
+from PyKCS11 import PyKCS11
+
+class TestUtil(unittest.TestCase):
+    def setUp(self):
+        self.pkcs11 = PyKCS11.PyKCS11Lib()
+        self.pkcs11.load()
+
+        # get SoftHSM major version
+        info = self.pkcs11.getInfo()
+        self.SoftHSMversion = info.libraryVersion[0]
+        self.manufacturer = info.manufacturerID
+
+        self.slot = self.pkcs11.getSlotList(tokenPresent=True)[0]
+        self.session = self.pkcs11.openSession(
+            self.slot, PyKCS11.CKF_SERIAL_SESSION | PyKCS11.CKF_RW_SESSION
+        )
+        self.session.login("1234")
+
+        # Select the curve to be used for the keys
+        curve = u"secp256r1"
+
+        # Setup the domain parameters, unicode conversion needed
+        # for the curve string
+        domain_params = ECDomainParameters(name="named", value=NamedCurve(curve))
+        self.ecParams = domain_params.dump()
+
+        keyID = (0x01,)
+        baseKeyPubTemplate = [
+            (PyKCS11.CKA_CLASS, PyKCS11.CKO_PUBLIC_KEY),
+            (PyKCS11.CKA_PRIVATE, PyKCS11.CK_FALSE),
+            (PyKCS11.CKA_TOKEN, PyKCS11.CK_TRUE),
+            (PyKCS11.CKA_ENCRYPT, PyKCS11.CK_TRUE),
+            (PyKCS11.CKA_VERIFY, PyKCS11.CK_TRUE),
+            (PyKCS11.CKA_WRAP, PyKCS11.CK_TRUE),
+            (PyKCS11.CKA_KEY_TYPE, PyKCS11.CKK_ECDSA),
+            (PyKCS11.CKA_EC_PARAMS, self.ecParams),
+            (PyKCS11.CKA_LABEL, "TestBaseKeyP256"),
+            (PyKCS11.CKA_ID, keyID),
+        ]
+        baseKeyPvtTemplate = [
+            (PyKCS11.CKA_CLASS, PyKCS11.CKO_PRIVATE_KEY),
+            (PyKCS11.CKA_KEY_TYPE, PyKCS11.CKK_ECDSA),
+            (PyKCS11.CKA_TOKEN, PyKCS11.CK_TRUE),
+            (PyKCS11.CKA_SENSITIVE, PyKCS11.CK_TRUE),
+            (PyKCS11.CKA_PRIVATE, PyKCS11.CK_FALSE),
+            (PyKCS11.CKA_DECRYPT, PyKCS11.CK_TRUE),
+            (PyKCS11.CKA_SIGN, PyKCS11.CK_TRUE),
+            (PyKCS11.CKA_UNWRAP, PyKCS11.CK_TRUE),
+            (PyKCS11.CKA_LABEL, "TestBaseKeyP256"),
+            (PyKCS11.CKA_ID, keyID),
+            (PyKCS11.CKA_DERIVE, PyKCS11.CK_TRUE),
+        ]
+        mechanism = PyKCS11.Mechanism(PyKCS11.CKM_EC_KEY_PAIR_GEN, None)
+        self.baseEcPubKey, self.baseEcPvtKey = self.session.generateKeyPair(baseKeyPubTemplate, baseKeyPvtTemplate, mechanism)
+        self.assertIsNotNone(self.baseEcPubKey)
+        self.assertIsNotNone(self.baseEcPvtKey)
+
+        # Known base symmetric key
+        knownAESKeyValue = bytes([0xAA, 0xAA, 0xAA, 0xAA, 0xBB, 0xBB, 0xBB, 0xBB,
+                                        0xCC, 0xCC, 0xCC, 0xCC, 0xDD, 0xDD, 0xDD, 0xDD])
+
+        keyID = (0x11,)
+        wrapKeyTemplate = [
+            (PyKCS11.CKA_CLASS, PyKCS11.CKO_SECRET_KEY),
+            (PyKCS11.CKA_KEY_TYPE, PyKCS11.CKK_AES),
+            (PyKCS11.CKA_TOKEN, PyKCS11.CK_FALSE),
+            (PyKCS11.CKA_SENSITIVE, PyKCS11.CK_TRUE),
+            (PyKCS11.CKA_PRIVATE, PyKCS11.CK_TRUE),
+            (PyKCS11.CKA_ENCRYPT, PyKCS11.CK_TRUE),
+            (PyKCS11.CKA_UNWRAP, PyKCS11.CK_TRUE),
+            (PyKCS11.CKA_VALUE_LEN, 16),
+            (PyKCS11.CKA_LABEL, "wrap"),
+            (PyKCS11.CKA_ID, keyID),
+        ]
+        mechanism = PyKCS11.Mechanism(PyKCS11.CKM_AES_KEY_GEN, None)
+        AESKey = self.session.generateKey(wrapKeyTemplate, mechanism)
+        self.assertIsNotNone(AESKey)
+
+        mechanism = PyKCS11.Mechanism(PyKCS11.CKM_AES_ECB, None)
+        wrappedKey = self.session.encrypt(AESKey, knownAESKeyValue, mechanism)
+        self.assertIsNotNone(wrappedKey)
+        keyID = (0x02,)
+        baseAESKeyTemplate = [
+            (PyKCS11.CKA_CLASS, PyKCS11.CKO_SECRET_KEY),
+            (PyKCS11.CKA_KEY_TYPE, PyKCS11.CKK_AES),
+            (PyKCS11.CKA_TOKEN, PyKCS11.CK_TRUE),
+            (PyKCS11.CKA_SENSITIVE, PyKCS11.CK_TRUE),
+            (PyKCS11.CKA_PRIVATE, PyKCS11.CK_TRUE),
+            (PyKCS11.CKA_ENCRYPT, PyKCS11.CK_TRUE),
+            (PyKCS11.CKA_DECRYPT, PyKCS11.CK_TRUE),
+            (PyKCS11.CKA_SIGN, PyKCS11.CK_FALSE),
+            (PyKCS11.CKA_VERIFY, PyKCS11.CK_FALSE),
+            (PyKCS11.CKA_DERIVE, PyKCS11.CK_TRUE),
+            (PyKCS11.CKA_EXTRACTABLE, PyKCS11.CK_TRUE),
+            (PyKCS11.CKA_VALUE_LEN, 16),
+            (PyKCS11.CKA_LABEL, "TestBaseAESKey"),
+            (PyKCS11.CKA_ID, keyID),
+        ]
+        self.baseAESKey = self.session.unwrapKey(AESKey, wrappedKey, baseAESKeyTemplate, mechanism)
+        self.assertIsNotNone(self.baseAESKey)
+        self.session.destroyObject(AESKey)
+
+    def tearDown(self):
+        self.session.destroyObject(self.baseEcPubKey)
+        self.session.destroyObject(self.baseEcPvtKey)
+        self.session.destroyObject(self.baseAESKey)
+
+        self.session.logout()
+        self.pkcs11.closeAllSessions(self.slot)
+        del self.pkcs11
+
+    def test_deriveKey_ECDH1_DERIVE(self):
+        if self.SoftHSMversion < 2:
+            self.skipTest("generateKey() only supported by SoftHSM >= 2")
+
+        keyID = (0x22,)
+        pubTemplate = [
+            (PyKCS11.CKA_CLASS, PyKCS11.CKO_PUBLIC_KEY),
+            (PyKCS11.CKA_PRIVATE, PyKCS11.CK_FALSE),
+            (PyKCS11.CKA_TOKEN, PyKCS11.CK_FALSE),
+            (PyKCS11.CKA_ENCRYPT, PyKCS11.CK_TRUE),
+            (PyKCS11.CKA_VERIFY, PyKCS11.CK_TRUE),
+            (PyKCS11.CKA_WRAP, PyKCS11.CK_TRUE),
+            (PyKCS11.CKA_KEY_TYPE, PyKCS11.CKK_ECDSA),
+            (PyKCS11.CKA_EC_PARAMS, self.ecParams),
+            (PyKCS11.CKA_LABEL, "testKeyP256"),
+            (PyKCS11.CKA_ID, keyID),
+        ]
+        pvtTemplate = [
+            (PyKCS11.CKA_CLASS, PyKCS11.CKO_PRIVATE_KEY),
+            (PyKCS11.CKA_KEY_TYPE, PyKCS11.CKK_ECDSA),
+            (PyKCS11.CKA_TOKEN, PyKCS11.CK_FALSE),
+            (PyKCS11.CKA_SENSITIVE, PyKCS11.CK_TRUE),
+            (PyKCS11.CKA_PRIVATE, PyKCS11.CK_TRUE),
+            (PyKCS11.CKA_DECRYPT, PyKCS11.CK_TRUE),
+            (PyKCS11.CKA_SIGN, PyKCS11.CK_TRUE),
+            (PyKCS11.CKA_UNWRAP, PyKCS11.CK_TRUE),
+            (PyKCS11.CKA_LABEL, "testKeyP256"),
+            (PyKCS11.CKA_ID, keyID),
+            (PyKCS11.CKA_DERIVE, PyKCS11.CK_TRUE),
+        ]
+        mechanism = PyKCS11.Mechanism(PyKCS11.CKM_EC_KEY_PAIR_GEN, None)
+        pubKey, pvtKey = self.session.generateKeyPair(pubTemplate, pvtTemplate, mechanism)
+        self.assertIsNotNone(pubKey)
+        self.assertIsNotNone(pvtKey)
+
+        keyID = (0x33,)
+        derivedAESKeyTemplate = [
+            (PyKCS11.CKA_CLASS, PyKCS11.CKO_SECRET_KEY),
+            (PyKCS11.CKA_KEY_TYPE, PyKCS11.CKK_AES),
+            (PyKCS11.CKA_TOKEN, PyKCS11.CK_FALSE),
+            (PyKCS11.CKA_SENSITIVE, PyKCS11.CK_TRUE),
+            (PyKCS11.CKA_PRIVATE, PyKCS11.CK_TRUE),
+            (PyKCS11.CKA_ENCRYPT, PyKCS11.CK_TRUE),
+            (PyKCS11.CKA_DECRYPT, PyKCS11.CK_TRUE),
+            (PyKCS11.CKA_SIGN, PyKCS11.CK_FALSE),
+            (PyKCS11.CKA_EXTRACTABLE, PyKCS11.CK_TRUE),
+            (PyKCS11.CKA_VERIFY, PyKCS11.CK_FALSE),
+            (PyKCS11.CKA_VALUE_LEN, 24),
+            (PyKCS11.CKA_LABEL, "derivedAESKey"),
+            (PyKCS11.CKA_ID, keyID),
+        ]
+
+        # derive key 1 : self.basePvtKey + pubKey
+        attrs = self.session.getAttributeValue(pubKey, [PyKCS11.CKA_EC_POINT], True)
+        mechanism = PyKCS11.ECDH1_DERIVE_Mechanism(bytes(attrs[0]))
+        derivedKey = self.session.deriveKey(self.baseEcPvtKey, derivedAESKeyTemplate, mechanism)
+        self.assertIsNotNone(derivedKey)
+
+        # derive key 2 : pvtKey + self.basePubKey
+        attrs = self.session.getAttributeValue(self.baseEcPubKey, [PyKCS11.CKA_EC_POINT], True)
+        mechanism = PyKCS11.ECDH1_DERIVE_Mechanism(bytes(attrs[0]))
+        derivedKey2 = self.session.deriveKey(pvtKey, derivedAESKeyTemplate, mechanism)
+        self.assertIsNotNone(derivedKey2)
+
+        DataIn = "Sample data to test ecdh1 derive".encode("utf-8")
+        mechanism = PyKCS11.Mechanism(PyKCS11.CKM_AES_CBC, "1234567812345678")
+        DataOut = self.session.encrypt(derivedKey, DataIn, mechanism)
+        DataCheck = self.session.decrypt(derivedKey2, DataOut, mechanism)
+
+        # match check values
+        self.assertSequenceEqual(DataIn, DataCheck)
+
+        # cleanup
+        self.session.destroyObject(derivedKey)
+        self.session.destroyObject(derivedKey2)
+        self.session.destroyObject(pubKey)
+        self.session.destroyObject(pvtKey)
+
+    def test_deriveKey_CONCATENATE_BASE_AND_DATA(self):
+        knownCheckValue = (0x5A, 0x71, 0x81)
+
+        # to derive key
+        derivationData = PyKCS11.ckbytelist([42] * 16)
+        # to calculate key check value
+        data = [0] * 16
+        # known key check value with know base key and derivation data
+        keyID = (0x22,)
+        derivedAESKeyTemplate = [
+            (PyKCS11.CKA_CLASS, PyKCS11.CKO_SECRET_KEY),
+            (PyKCS11.CKA_KEY_TYPE, PyKCS11.CKK_AES),
+            (PyKCS11.CKA_TOKEN, PyKCS11.CK_FALSE),
+            (PyKCS11.CKA_SENSITIVE, PyKCS11.CK_TRUE),
+            (PyKCS11.CKA_PRIVATE, PyKCS11.CK_FALSE),
+            (PyKCS11.CKA_ENCRYPT, PyKCS11.CK_TRUE),
+            (PyKCS11.CKA_DECRYPT, PyKCS11.CK_TRUE),
+            (PyKCS11.CKA_SIGN, PyKCS11.CK_FALSE),
+            (PyKCS11.CKA_EXTRACTABLE, PyKCS11.CK_TRUE),
+            (PyKCS11.CKA_VERIFY, PyKCS11.CK_FALSE),
+            (PyKCS11.CKA_VALUE_LEN, 32),
+            (PyKCS11.CKA_LABEL, "derivedAES256Key"),
+            (PyKCS11.CKA_ID, keyID),
+        ]
+
+        if self.manufacturer.startswith("SoftHSM"):
+            self.skipTest("SoftHSMv2 does not support CKM_CONCATENATE_BASE_AND_DATA.")
+
+        # mechanism = PyKCS11.Mechanism(PyKCS11.CKM_CONCATENATE_BASE_AND_DATA, params)
+        params = PyKCS11.LowLevel.CK_KEY_DERIVATION_STRING_DATA()
+        params.pData = derivationData
+        params.ulLen = len(derivationData)
+        mechanism = PyKCS11.LowLevel.CK_MECHANISM()
+        mechanism.mechanism = PyKCS11.CKM_CONCATENATE_BASE_AND_DATA
+        mechanism.pParameter = params
+        mechanism.ulParameterLen = PyKCS11.LowLevel.CK_KEY_DERIVATION_STRING_DATA_LENGTH
+        derivedKey = self.session.deriveKey(self.baseAESKey, derivedAESKeyTemplate, mechanism)
+
+        # generate key check value
+        mechanism = PyKCS11.Mechanism(PyKCS11.CKM_AES_ECB, None)
+        checkValue = self.session.encrypt(derivedKey, data, mechanism)
+
+        # match check values
+        self.assertSequenceEqual(knownCheckValue, checkValue[0:3]) # ZL6
+
+        # cleanup
+        self.session.destroyObject(derivedKey)


### PR DESCRIPTION
Adds C_DeriveKey() PKCS#11 Support
Adds handling of CK_ECDH1_DERIVE_PARAMS struct
Adds handling of CK_KEY_DERIVATION_STRING_DATA struct
Adds handling of CK_ECIES_PARAMS struct
void* parameters such as pSourceData of CK_RSA_PKCS_OAEP_PARAMS

Allows user defined mechanism parameters. void * in pParameter can
accomodate any type. checking isinstance in deriveKey() is an example
how a user can leverage LowLevel.CK_MECHANISM for arbitrary parameters
as void* here translates to Ckbytelist

Adds test for CKM_ECDH1_DERIVE
Adds test for CKM_CONCATENATE_BASE_AND_DATA

Contributors: 
balsingh <baljindersingh.kpt@gmail.com>
Michał Skalski <mskalski@enigma.com.pl>