### PR TITLE
Fix incorrect application state after a failed attempt to load a PKCS#11 library

### DIFF
--- a/PyKCS11/__init__.py
+++ b/PyKCS11/__init__.py
@@ -510,13 +510,13 @@ class PyKCS11Lib(object):
             self.lib.Duplicate(PyKCS11Lib._loaded_libs[pkcs11dll_filename]["ref"])
         else:
             # else load it
+            rv = self.lib.Load(pkcs11dll_filename)
+            if rv != CKR_OK:
+                raise PyKCS11Error(rv, pkcs11dll_filename)
             PyKCS11Lib._loaded_libs[pkcs11dll_filename] = {
                     "ref": self.lib,
                     "nb_users": 0
                     }
-            rv = self.lib.Load(pkcs11dll_filename)
-            if rv != CKR_OK:
-                raise PyKCS11Error(rv, pkcs11dll_filename)
 
         # increase user number
         PyKCS11Lib._loaded_libs[pkcs11dll_filename]["nb_users"] += 1

--- a/test/test_load.py
+++ b/test/test_load.py
@@ -40,3 +40,12 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(the_exception.text, lib)
         self.assertEqual(str(the_exception),
             "C_GetFunctionList() not found (%s)" % lib)
+
+        # try to load the improper lib another time
+        with self.assertRaises(PyKCS11.PyKCS11Error) as cm:
+            self.pkcs11.load(lib)
+        the_exception = cm.exception
+        self.assertEqual(the_exception.value, -4)
+        self.assertEqual(the_exception.text, lib)
+        self.assertEqual(str(the_exception),
+            "C_GetFunctionList() not found (%s)" % lib)


### PR DESCRIPTION
Calling the method `self.pkcs11.load(lib)` twice leads to an incorrect state of the application, if the first attempt to load a library failed. The problem is that code in `__init__.py` fills the map `_loaded_libs` with the library name before the library is actually loaded, and then the next call to `self.pkcs11.load(lib)` finds the cached library (which wasn't properly loaded) and finishes successfully.
The bug can be reproduced by simply setting an invalid PKCS#11 library name and executing the unit tests:
```
export PYKCS11LIB=/path/to/invalid/lib.so
./run_test.py
```
which in my case ended up with a segfault.
This PR proposes a fix for the problem.