### PR TITLE
add AES in counter mode support

### DIFF
--- a/PyKCS11/__init__.py
+++ b/PyKCS11/__init__.py
@@ -812,6 +812,29 @@ class AES_GCM_Mechanism(object):
         return self._mech
 
 
+class AES_CTR_Mechanism(object):
+    """CKM_AES_CTR encryption mechanism"""
+
+    def __init__(self, counterBits, counterBlock):
+        """
+        :param counterBits: the number of incremented bits in the counter block
+        :param counterBlock: a 16-byte initial value of the counter block
+        """
+        self._param = PyKCS11.LowLevel.CK_AES_CTR_PARAMS()
+
+        self._source_cb = ckbytelist(counterBlock)
+        self._param.ulCounterBits = counterBits
+        self._param.cb = self._source_cb
+
+        self._mech = PyKCS11.LowLevel.CK_MECHANISM()
+        self._mech.mechanism = CKM_AES_CTR
+        self._mech.pParameter = self._param
+        self._mech.ulParameterLen = PyKCS11.LowLevel.CK_AES_CTR_PARAMS_LENGTH
+
+    def to_native(self):
+        return self._mech
+
+
 class RSAOAEPMechanism(object):
     """RSA OAEP Wrapping mechanism"""
 

--- a/src/opensc/pkcs11.h
+++ b/src/opensc/pkcs11.h
@@ -756,6 +756,11 @@ struct ck_gcm_params {
   unsigned long ulTagBits;
 } ;
 
+struct ck_aes_ctr_params {
+  unsigned long ulCounterBits;
+  unsigned char cb[16];
+} ;
+
 struct ck_ecdh1_derive_params {
   unsigned long kdf;
   unsigned long ulSharedDataLen;
@@ -1334,6 +1339,9 @@ typedef struct ck_rsa_pkcs_pss_params CK_RSA_PKCS_PSS_PARAMS;
 typedef struct ck_rsa_pkcs_pss_params *CK_RSA_PKCS_PSS_PARAMS_PTR;
 
 typedef struct ck_gcm_params CK_GCM_PARAMS;
+
+typedef struct ck_aes_ctr_params CK_AES_CTR_PARAMS;
+typedef struct ck_aes_ctr_params *CK_AES_CTR_PARAMS_PTR;
 
 typedef struct ck_ecdh1_derive_params CK_ECDH1_DERIVE_PARAMS;
 typedef struct ck_ecdh1_derive_params *CK_ECDH1_DERIVE_PARAMS_PTR;

--- a/test/test_symetric.py
+++ b/test/test_symetric.py
@@ -93,6 +93,17 @@ class TestUtil(unittest.TestCase):
         # 2nd block
         self.assertSequenceEqual(DataOut[16:], DataECBOut2)
 
+        # AES CTR with IV
+        mechanism = PyKCS11.AES_CTR_Mechanism(128, "1234567812345678")
+
+        DataOut = self.session.encrypt(symKey, DataIn, mechanism)
+        # print("DataOut", DataOut)
+
+        DataCheck = self.session.decrypt(symKey, DataOut, mechanism)
+        # print("DataCheck:", DataCheck)
+
+        self.assertSequenceEqual(DataIn, DataCheck)
+
         #
         # test CK_GCM_PARAMS
         #


### PR DESCRIPTION
- Added support of `CKM_AES_CTR` and `CK_AES_CTR_PARAMS` as per PKCS#11 3.0 specification (see [section 2.11](https://docs.oasis-open.org/pkcs11/pkcs11-curr/v3.0/os/pkcs11-curr-v3.0-os.html#_Toc30061249))
- Improved `%typemap(in) void*`: replaced nested if with a linear `do{...}while(0);` (simplifies adding new typemaps for parameter structures)