### PR TITLE
Add simple derivation mechanisms support

### DIFF
--- a/PyKCS11/__init__.py
+++ b/PyKCS11/__init__.py
@@ -922,6 +922,75 @@ class ECDH1_DERIVE_Mechanism(object):
 
     def to_native(self):
         return self._mech
+    
+
+class CONCATENATE_BASE_AND_KEY_Mechanism(object):
+    """CKM_CONCATENATE_BASE_AND_KEY key derivation mechanism"""
+
+    def __init__(self, encKey):
+        """
+        :param encKey: a handle of encryption key
+        """
+        self._mech = PyKCS11.LowLevel.CK_MECHANISM()
+        self._mech.mechanism = CKM_CONCATENATE_BASE_AND_KEY
+        self._mech.pParameter = encKey
+        self._mech.ulParameterLen = PyKCS11.LowLevel.CK_OBJECT_HANDLE_LENGTH
+
+    def to_native(self):
+        return self._mech
+
+
+class KEY_DERIVATION_STRING_DATA_MechanismBase(object):
+    """Base class for mechanisms using derivation string data"""
+
+    def __init__(self, data, mechType):
+        """
+        :param data: a byte array to concatenate the key with
+        :param mechType: mechanism type
+        """
+        self._param = PyKCS11.LowLevel.CK_KEY_DERIVATION_STRING_DATA()
+
+        self._data = ckbytelist(data)
+        self._param.pData = self._data
+        self._param.ulLen = len(self._data)
+
+        self._mech = PyKCS11.LowLevel.CK_MECHANISM()
+        self._mech.mechanism = mechType
+        self._mech.pParameter = self._param
+        self._mech.ulParameterLen = PyKCS11.LowLevel.CK_KEY_DERIVATION_STRING_DATA_LENGTH
+
+    def to_native(self):
+        return self._mech
+    
+
+class CONCATENATE_BASE_AND_DATA_Mechanism(KEY_DERIVATION_STRING_DATA_MechanismBase):
+    """CKM_CONCATENATE_BASE_AND_DATA key derivation mechanism"""
+
+    def __init__(self, data):
+        """
+        :param data: a byte array to concatenate the key with
+        """
+        super().__init__(data, CKM_CONCATENATE_BASE_AND_DATA)
+    
+
+class CONCATENATE_DATA_AND_BASE_Mechanism(KEY_DERIVATION_STRING_DATA_MechanismBase):
+    """CKM_CONCATENATE_DATA_AND_BASE key derivation mechanism"""
+
+    def __init__(self, data):
+        """
+        :param data: a byte array to concatenate the key with
+        """
+        super().__init__(data, CKM_CONCATENATE_DATA_AND_BASE)
+
+
+class XOR_BASE_AND_DATA_Mechanism(KEY_DERIVATION_STRING_DATA_MechanismBase):
+    """CKM_XOR_BASE_AND_DATA key derivation mechanism"""
+
+    def __init__(self, data):
+        """
+        :param data: a byte array to xor the key with
+        """
+        super().__init__(data, CKM_XOR_BASE_AND_DATA)
 
 
 class DigestSession(object):

--- a/src/opensc/pkcs11.h
+++ b/src/opensc/pkcs11.h
@@ -769,6 +769,11 @@ struct ck_ecdh1_derive_params {
   void * pPublicData;
 } ;
 
+struct ck_key_derivation_string_data {
+  unsigned char * pData;
+  unsigned long ulLen;
+} ;
+
 #define CKF_HW			(1 << 0)
 #define CKF_ENCRYPT		(1 << 8)
 #define CKF_DECRYPT		(1 << 9)
@@ -1345,6 +1350,9 @@ typedef struct ck_aes_ctr_params *CK_AES_CTR_PARAMS_PTR;
 
 typedef struct ck_ecdh1_derive_params CK_ECDH1_DERIVE_PARAMS;
 typedef struct ck_ecdh1_derive_params *CK_ECDH1_DERIVE_PARAMS_PTR;
+
+typedef struct ck_key_derivation_string_data CK_KEY_DERIVATION_STRING_DATA;
+typedef struct ck_key_derivation_string_data *CK_KEY_DERIVATION_STRING_DATA_PTR;
 
 typedef struct ck_function_list CK_FUNCTION_LIST;
 typedef struct ck_function_list *CK_FUNCTION_LIST_PTR;

--- a/src/pykcs11.i
+++ b/src/pykcs11.i
@@ -267,11 +267,40 @@ typedef struct CK_DATE{
             res2 = SWIG_ConvertPtr($input, &arg2, $descriptor(CK_AES_CTR_PARAMS*), 0);
             if( SWIG_IsOK( res2 ) )
                 break;
+
+            res2 = SWIG_ConvertPtr($input, &arg2, $descriptor(CK_KEY_DERIVATION_STRING_DATA*), 0);
+            if( SWIG_IsOK( res2 ) )
+                break;
+
+            res2 = SWIG_ConvertPtr($input, &arg2, $descriptor(CK_OBJECT_HANDLE*), 0);
+            if( SWIG_IsOK( res2 ) )
+                break;
         } while(0);
 
         if (!SWIG_IsOK(res2)) {
             SWIG_exception_fail(SWIG_ArgError(res2), "unsupported CK_MECHANISM Parameter type.");
         }
+    }
+}
+
+// typemap for CK_BYTE_PTR (unsigned char*) mechanism parameters
+%typemap(in) unsigned char* {
+    vector<unsigned char> *vect;
+    // If the value being set is of ckbytelist type:
+    int res = SWIG_ConvertPtr($input, (void **)&vect, $descriptor(vector<unsigned char> *), 0);
+    if (SWIG_IsOK(res))
+    {
+        // Get the data from the vector
+        // Only set value if not null
+        if (vect)
+            arg2 = vect->data();
+        else
+            arg2 = NULL;
+    }
+    else
+    {
+        // If a mechanism parameter has a 'CK_BYTE_PTR' as a member, it must be represented as a ckbytelist
+        SWIG_exception_fail(SWIG_ArgError(res), "CK_BYTE_PTR members of CK_* mechanism params must be represented as ckbytelist type");
     }
 }
 
@@ -334,6 +363,8 @@ typedef struct CK_MECHANISM {
         SWIG_exception_fail(SWIG_ArgError(res), "void * members of CK_* mechanism params must be represented as ckbytelist type");
     }
 }
+
+%constant int CK_OBJECT_HANDLE_LENGTH = sizeof(CK_OBJECT_HANDLE);
 
 typedef struct CK_GCM_PARAMS {
     void * pIv;
@@ -442,6 +473,24 @@ typedef struct CK_ECDH1_DERIVE_PARAMS {
 };
 
 %constant int CK_ECDH1_DERIVE_PARAMS_LENGTH = sizeof(CK_ECDH1_DERIVE_PARAMS);
+
+typedef struct CK_KEY_DERIVATION_STRING_DATA {
+    unsigned char * pData;
+    unsigned long ulLen;
+} CK_KEY_DERIVATION_STRING_DATA;
+
+%extend CK_KEY_DERIVATION_STRING_DATA
+{
+    CK_KEY_DERIVATION_STRING_DATA()
+    {
+        CK_KEY_DERIVATION_STRING_DATA *p = new CK_KEY_DERIVATION_STRING_DATA();
+        p->ulLen = 0;
+        p->pData = NULL;
+        return p;
+    }
+};
+
+%constant int CK_KEY_DERIVATION_STRING_DATA_LENGTH = sizeof(CK_KEY_DERIVATION_STRING_DATA);
 
 typedef struct CK_MECHANISM_INFO {
 %immutable;


### PR DESCRIPTION
Added support of the following key derivation mechanisms (as per [section 2.43](https://docs.oasis-open.org/pkcs11/pkcs11-curr/v3.0/os/pkcs11-curr-v3.0-os.html#_Toc30061459) of the PKCS#11 3.0 specification):

- `CKM_CONCATENATE_BASE_AND_KEY`
- `CKM_CONCATENATE_BASE_AND_DATA`
- `CKM_CONCATENATE_DATA_AND_BASE`
- `CKM_XOR_BASE_AND_DATA`

_Unfortunately, these mechanisms are currently not supported by SoftHSM (2.6.1). However CKM_CONCATENATE* mechanisms are available in develop branch of SoftHSM (tested with a SoftHSM build from the develop branch)_