### PR TITLE
Fix reference counting in PyKCS11Lib.load

### DIFF
--- a/test/test_asymetric.py
+++ b/test/test_asymetric.py
@@ -56,6 +56,7 @@ class TestUtil(unittest.TestCase):
 
         self.session.logout()
         self.pkcs11.closeAllSessions(self.slot)
+        self.pkcs11.unload()
         del self.pkcs11
 
     def test_sign_integer(self):

--- a/test/test_asymetric_gost.py
+++ b/test/test_asymetric_gost.py
@@ -19,6 +19,7 @@ class TestUtil(unittest.TestCase):
     def tearDown(self):
         self.session.logout()
         self.pkcs11.closeAllSessions(self.slot)
+        self.pkcs11.unload()
         del self.pkcs11
 
     def test_gost(self):

--- a/test/test_derive.py
+++ b/test/test_derive.py
@@ -93,6 +93,7 @@ class TestUtil(unittest.TestCase):
 
         self.session.logout()
         self.pkcs11.closeAllSessions(self.slot)
+        self.pkcs11.unload()
         del self.pkcs11
 
     def getCkaValue(self, key):

--- a/test/test_load.py
+++ b/test/test_load.py
@@ -3,16 +3,69 @@
 import unittest
 from PyKCS11 import PyKCS11
 import platform
+import shutil
+import gc
 
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from get_PYKCS11LIB import get_PYKCS11LIB
 
 class TestUtil(unittest.TestCase):
     def setUp(self):
         self.pkcs11 = PyKCS11.PyKCS11Lib()
+        self.tmpdir = TemporaryDirectory()
+        self.lib1_name = get_PYKCS11LIB()
+        # create a tmp copy of the main lib 
+        # to use as a different library in tests
+        self.lib2_name = str(Path(self.tmpdir.name) / 
+                             Path(self.lib1_name).name)
+        shutil.copy(self.lib1_name, self.tmpdir.name)
 
     def tearDown(self):
         del self.pkcs11
+        del self.tmpdir
+        del self.lib1_name
+        del self.lib2_name
+
+    def openSession(self, lib):
+        slot = lib.getSlotList(tokenPresent=True)[0]
+        return lib.openSession(slot, PyKCS11.CKF_SERIAL_SESSION)
 
     def test_load(self):
+        # create two instances with default library
+        lib1 = PyKCS11.PyKCS11Lib().load()
+        lib2 = PyKCS11.PyKCS11Lib().load()
+
+        # expect two instances with the same library loaded
+        self.assertTrue(hasattr(lib1, "pkcs11dll_filename"))
+        self.assertTrue(hasattr(lib2, "pkcs11dll_filename"))
+        self.assertEqual(len(lib1._loaded_libs), 1)
+        self.assertEqual(len(lib2._loaded_libs), 1)
+
+        self.openSession(lib1)
+
+        # unload the first library
+        del lib1
+        gc.collect()
+
+        # one instance remaining, the library is still in use
+        self.openSession(lib2)
+        self.assertEqual(len(lib2._loaded_libs), 1)
+
+    def test_multiple_load(self):
+        # load two different libraries
+        lib1 = PyKCS11.PyKCS11Lib().load(self.lib1_name)
+        lib2 = PyKCS11.PyKCS11Lib().load(self.lib2_name)
+
+        # _loaded_libs is shared across all instances
+        # check the value in self.pkcs11
+        self.assertEqual(len(self.pkcs11._loaded_libs), 2)
+        lib1 = PyKCS11.PyKCS11Lib() # unload lib1
+        self.assertEqual(len(self.pkcs11._loaded_libs), 1)
+        lib2 = PyKCS11.PyKCS11Lib() # unload lib2
+        self.assertEqual(len(self.pkcs11._loaded_libs), 0)
+
+    def test_invalid_load(self):
         # Library not found
         lib = "nolib"
         with self.assertRaises(PyKCS11.PyKCS11Error) as cm:
@@ -21,6 +74,7 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(the_exception.value, -1)
         self.assertEqual(the_exception.text, lib)
         self.assertEqual(str(the_exception), "Load (%s)" % lib)
+        self.assertEqual(len(self.pkcs11._loaded_libs), 0)
 
         # C_GetFunctionList() not found
         if platform.system() == 'Linux':
@@ -40,6 +94,7 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(the_exception.text, lib)
         self.assertEqual(str(the_exception),
             "C_GetFunctionList() not found (%s)" % lib)
+        self.assertEqual(len(self.pkcs11._loaded_libs), 0)
 
         # try to load the improper lib another time
         with self.assertRaises(PyKCS11.PyKCS11Error) as cm:
@@ -49,3 +104,39 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(the_exception.text, lib)
         self.assertEqual(str(the_exception),
             "C_GetFunctionList() not found (%s)" % lib)
+        self.assertEqual(len(self.pkcs11._loaded_libs), 0)
+        
+        # finally, load a valid library
+        self.pkcs11.load()
+        self.assertEqual(len(self.pkcs11._loaded_libs), 1)
+
+    def test_specific_load(self):
+        # load two different libraries sequentially
+        self.pkcs11.load(self.lib1_name)
+        self.pkcs11.load(self.lib2_name)
+
+        # the second load should've unloaded the first library
+        self.assertEqual(len(self.pkcs11._loaded_libs), 1)
+        self.assertEqual(self.pkcs11.pkcs11dll_filename, self.lib2_name)
+
+        # reload the first library
+        self.pkcs11 = PyKCS11.PyKCS11Lib()
+        self.pkcs11.load(self.lib1_name)
+        
+        # try to open a session
+        self.assertIsNotNone(self.openSession(self.pkcs11))
+
+    def test_unload(self):
+        self.pkcs11.load().unload()
+        # no pkcs11dll_filename should remain after unload
+        self.assertFalse(hasattr(self.pkcs11, "pkcs11dll_filename"))
+        self.pkcs11.load()
+        self.openSession(self.pkcs11)
+        # one library has been loaded
+        self.assertEqual(len(self.pkcs11._loaded_libs), 1)
+        self.assertTrue(hasattr(self.pkcs11, "pkcs11dll_filename"))
+        self.pkcs11.unload()
+        gc.collect()
+        # manually unloaded the library using gc.collect()
+        self.assertEqual(len(self.pkcs11._loaded_libs), 0)
+        self.assertFalse(hasattr(self.pkcs11, "pkcs11dll_filename"))


### PR DESCRIPTION
Fixes incorrect reference counting for `PyKCS11Lib._loaded_libs`

The bug can be reproduced with the following steps (this case is implemented in `test_specific_load`):

1. Create an instance of `PyKCS11Lib` and load a PKCS#11 library
2. Load another library using `PyKCS11Lib.load` method. At this step `PyKCS11Lib` doesn't unload the first library and decrement the reference counter on it, i.e. we have two entries in `_loaded_libs` map pointing to the same `CPKCS11Lib` object.
3. Unload the second library: `PyKCS11Lib` removes the corresponding entry from `_loaded_libs` and invokes `self.lib.Unload()`, so now we have a dangling entry of the first library pointing to the same `CPKCS11Lib` object, on which `Unload` has been called.
4. Load the first library again: `PyKCS11Lib` calls `Duplicate` with the dangling entry in `_loaded_libs`.
5. Now, try to perform any operation with `PyKCS11Lib` => causes a segfault

While investigating this problem I found it convenient to add a `PyKCS11Lib.unload` method, which allows to explicitly unload the PKCS#11 library. I also added a couple of tests which require two different PKCS#11 libraries to run, which is not the case in the testing enviroment (with a single SoftHSM) you are currently using, so I had to create a temporary copy of libsofthsm2.so to make them work.

_By the way, the current implementation of load(unload) is not thread safe, since it operates with an unprotected shared map (`_loaded_libs`). However, I'm not sure how much of an issue this is. I'd say, just marking these methods as non thread safe is pretty much acceptable as for me._