### PR TITLE
Remove python 2 support from ckbytelist constructor

### DIFF
--- a/PyKCS11/__init__.py
+++ b/PyKCS11/__init__.py
@@ -76,41 +76,17 @@ class ckbytelist(PyKCS11.LowLevel.ckbytelist):
     add a __repr__() method to the LowLevel equivalent
     """
 
-    def __init__(self, data=[]):
-        # default size of the vector
-        size = 0
-        super(ckbytelist, self).__init__(size)
-
-        # No value to initialize
+    def __init__(self, data=None):
         if data is None:
-            return
-
-        # b'abc'
-        if isinstance(data, bytes):
-            self.reserve(len(data))
-            for x in data:
-                if sys.version_info[0] <= 2:
-                    # Python 2
-                    v = ord(x)
-                else:
-                    # Python 3 and more
-                    v = x
-                self.append(v)
-
-        # "abc"
+            data = 0
         elif isinstance(data, str):
-            tmp = bytes(data, "utf-8")
-            self.reserve(len(tmp))
-            for x in tmp:
-                self.append(x)
-
-        # [141, 142, 143]
-        elif isinstance(data, list) or isinstance(data, ckbytelist):
-            self.reserve(len(data))
-            for c in range(len(data)):
-                self.append(data[c])
+            data = data.encode("utf-8")
+        elif isinstance(data, (bytes, list, ckbytelist)):
+            data = bytes(data)
         else:
             raise PyKCS11.PyKCS11Error(-3, text=str(type(data)))
+        super(ckbytelist, self).__init__(data)
+
 
     def __repr__(self):
         """


### PR DESCRIPTION
The problem: `ckbytelist` constructor checks python version for every byte in a loop:
```
for x in data:
    if sys.version_info[0] <= 2:
        # Python 2
        v = ord(x)
    else:
        # Python 3 and more
        v = x
    self.append(v)
```
which is redundant and not good for performance. I suppose, just checking python version once during module import would suffice. This PR removes support of python 2 from `ckbytelist` class, since python 2 is not supported anymore.

The performance issue can be illustrated with a simple benchmark command:
```
python3 -m timeit -s "import PyKCS11" "PyKCS11.ckbytelist(b'x'*100)"
```
_For instance, on my system it now runs about six times faster compared to master._