### PR TITLE
bugfix: store CKM_CONCATENATE_BASE_AND_KEY parameter in the mechanism context

### DIFF
--- a/PyKCS11/__init__.py
+++ b/PyKCS11/__init__.py
@@ -942,9 +942,11 @@ class CONCATENATE_BASE_AND_KEY_Mechanism:
         """
         :param encKey: a handle of encryption key
         """
+        self._encKey = encKey
+
         self._mech = PyKCS11.LowLevel.CK_MECHANISM()
         self._mech.mechanism = CKM_CONCATENATE_BASE_AND_KEY
-        self._mech.pParameter = encKey
+        self._mech.pParameter = self._encKey
         self._mech.ulParameterLen = PyKCS11.LowLevel.CK_OBJECT_HANDLE_LENGTH
 
     def to_native(self):

--- a/test/test_derive.py
+++ b/test/test_derive.py
@@ -223,7 +223,8 @@ class TestUtil(unittest.TestCase):
 
         # check that mechanism shares ownership of temporary key
         mechanism = PyKCS11.CONCATENATE_BASE_AND_KEY_Mechanism(
-            self.session.generateKey(concatenateKeyTemplate, key_gen_mechanism))
+            self.session.generateKey(concatenateKeyTemplate, key_gen_mechanism)
+        )
         derivedKey = self.session.deriveKey(self.baseKey, derivedKeyTemplate, mechanism)
         self.assertIsNotNone(derivedKey)
 

--- a/test/test_derive.py
+++ b/test/test_derive.py
@@ -199,8 +199,8 @@ class TestUtil(unittest.TestCase):
         # generate a key to concatenate with
         keyID = (0x11,)
         concatenateKeyTemplate = self.aesKeyTemplate + [(PyKCS11.CKA_ID, keyID)]
-        mechanism = PyKCS11.Mechanism(PyKCS11.CKM_AES_KEY_GEN, None)
-        concKey = self.session.generateKey(concatenateKeyTemplate, mechanism)
+        key_gen_mechanism = PyKCS11.Mechanism(PyKCS11.CKM_AES_KEY_GEN, None)
+        concKey = self.session.generateKey(concatenateKeyTemplate, key_gen_mechanism)
         self.assertIsNotNone(concKey)
 
         # concatenate two keys
@@ -220,6 +220,12 @@ class TestUtil(unittest.TestCase):
 
         # match: check values
         self.assertSequenceEqual(baseKeyValue + concKeyValue, derivedKeyValue)
+
+        # check that mechanism shares ownership of temporary key
+        mechanism = PyKCS11.CONCATENATE_BASE_AND_KEY_Mechanism(
+            self.session.generateKey(concatenateKeyTemplate, key_gen_mechanism))
+        derivedKey = self.session.deriveKey(self.baseKey, derivedKeyTemplate, mechanism)
+        self.assertIsNotNone(derivedKey)
 
         # cleanup
         self.session.destroyObject(derivedKey)


### PR DESCRIPTION
This PR fixes a bug in the case where the mechanism is used with a temporary key parameter (the mechanism class ought to store a reference to the parameter like the other mechanisms do).