### PR TITLE
update OpenSC headers to comply PKCS#11 3.0 specification

### DIFF
--- a/PyKCS11/__init__.py
+++ b/PyKCS11/__init__.py
@@ -859,7 +859,7 @@ class RSAOAEPMechanism:
         self._param.hashAlg = hashAlg
         self._param.mgf = mgf
         self._source = None
-        self._param.src = CKZ_DATA_SPECIFIED
+        self._param.source = CKZ_DATA_SPECIFIED
         if label:
             self._source = ckbytelist(label)
             self._param.ulSourceDataLen = len(self._source)

--- a/src/opensc/pkcs11.h
+++ b/src/opensc/pkcs11.h
@@ -63,9 +63,9 @@ extern "C" {
    version of this file, please consider deleting the revision macro
    (you may use a macro with a different name to keep track of your
    versions).  */
-#define CRYPTOKI_VERSION_MAJOR		2
-#define CRYPTOKI_VERSION_MINOR		20
-#define CRYPTOKI_VERSION_REVISION	6
+#define CRYPTOKI_VERSION_MAJOR		3
+#define CRYPTOKI_VERSION_MINOR		0
+#define CRYPTOKI_VERSION_REVISION	0
 
 
 /* Compatibility interface is default, unless CRYPTOKI_GNU is
@@ -736,9 +736,9 @@ struct ck_mechanism_info
 struct ck_rsa_pkcs_oaep_params {
   unsigned long hashAlg;
   unsigned long mgf;
-  unsigned long src;
-  void *source_data;
-  unsigned long source_data_len;
+  unsigned long source;
+  void *pSourceData;
+  unsigned long ulSourceDataLen;
 } ;
 
 struct ck_rsa_pkcs_pss_params {
@@ -764,9 +764,9 @@ struct ck_aes_ctr_params {
 struct ck_ecdh1_derive_params {
   unsigned long kdf;
   unsigned long ulSharedDataLen;
-  void * pSharedData;
+  unsigned char * pSharedData;
   unsigned long ulPublicDataLen;
-  void * pPublicData;
+  unsigned char * pPublicData;
 } ;
 
 struct ck_key_derivation_string_data {

--- a/src/pykcs11.i
+++ b/src/pykcs11.i
@@ -371,9 +371,10 @@ typedef struct CK_MECHANISM {
 %constant int CK_OBJECT_HANDLE_LENGTH = sizeof(CK_OBJECT_HANDLE);
 
 typedef struct CK_GCM_PARAMS {
-    void * pIv;
+    unsigned char * pIv;
     unsigned long ulIvLen;
-    void * pAAD;
+    unsigned long ulIvBits;
+    unsigned char * pAAD;
     unsigned long ulAADLen;
     unsigned long ulTagBits;
 } CK_GCM_PARAMS;
@@ -384,7 +385,7 @@ typedef struct CK_GCM_PARAMS {
     {
         CK_GCM_PARAMS *p = new CK_GCM_PARAMS();
         p->pIv = p->pAAD = NULL;
-        p->ulIvLen = p->ulAADLen = p->ulTagBits = 0;
+        p->ulIvLen = p->ulIvBits = p->ulAADLen = p->ulTagBits = 0;
         return p;
     }
 };
@@ -412,7 +413,7 @@ typedef struct CK_AES_CTR_PARAMS {
 typedef struct CK_RSA_PKCS_OAEP_PARAMS {
   unsigned long hashAlg;
   unsigned long mgf;
-  unsigned long src;
+  unsigned long source;
   void* pSourceData;
   unsigned long ulSourceDataLen;
 } CK_RSA_PKCS_OAEP_PARAMS;
@@ -424,9 +425,9 @@ typedef struct CK_RSA_PKCS_OAEP_PARAMS {
 		CK_RSA_PKCS_OAEP_PARAMS* p = new CK_RSA_PKCS_OAEP_PARAMS();
 		p->hashAlg = 0;
 		p->mgf = 0;
-		p->src = 0;
-		p->source_data = NULL;
-		p->source_data_len = 0;
+		p->source = 0;
+		p->pSourceData = NULL;
+		p->ulSourceDataLen = 0;
     return p;
 	}
 };
@@ -456,9 +457,9 @@ typedef struct CK_RSA_PKCS_PSS_PARAMS {
 typedef struct CK_ECDH1_DERIVE_PARAMS {
     unsigned long kdf;
     unsigned long ulSharedDataLen;
-    void* pSharedData;
+    unsigned char* pSharedData;
     unsigned long ulPublicDataLen;
-    void* pPublicData;
+    unsigned char* pPublicData;
 } CK_ECDH1_DERIVE_PARAMS;
 
 %extend CK_ECDH1_DERIVE_PARAMS


### PR DESCRIPTION
- Update PKCS#11 interface version to 3.0.
- Update the definitions of CK_GCM_PARAMS, CK_RSA_PKCS_OAEP_PARAMS, CK_ECDH1_DERIVE_PARAMS in accordance with PKCS#11 3.0 headers.

The latest pkcs11.h header from [OpenSC](https://github.com/OpenSC/OpenSC) was used as the reference.