### PR TITLE
use ckbytelist as return type

### DIFF
--- a/PyKCS11/__init__.py
+++ b/PyKCS11/__init__.py
@@ -1230,7 +1230,7 @@ class Session:
           (use `MechanismSHA1` for `CKM_SHA_1`)
         :type mecha: :class:`Mechanism`
         :return: the computed digest
-        :rtype: list of bytes
+        :rtype: ckbytelist
 
         :note: the returned value is an istance of :class:`ckbytelist`.
           You can easly convert it to a binary string with:
@@ -1267,7 +1267,7 @@ class Session:
           (use `MechanismRSAPKCS1` for `CKM_RSA_PKCS`)
         :type mecha: :class:`Mechanism`
         :return: the computed signature
-        :rtype: list of bytes
+        :rtype: ckbytelist
 
         :note: the returned value is an instance of :class:`ckbytelist`.
           You can easly convert it to a binary string with:
@@ -1334,7 +1334,7 @@ class Session:
           (use `MechanismRSAPKCS1` for `CKM_RSA_PKCS`)
         :type mecha: :class:`Mechanism`
         :return: the encrypted data
-        :rtype: list of bytes
+        :rtype: ckbytelist
 
         :note: the returned value is an instance of :class:`ckbytelist`.
           You can easly convert it to a binary string with:
@@ -1412,7 +1412,7 @@ class Session:
         :type mecha: :class:`Mechanism` instance or :class:`MechanismRSAPKCS1`
           for CKM_RSA_PKCS
         :return: the decrypted data
-        :rtype: list of bytes
+        :rtype: ckbytelist
 
         :note: the returned value is an instance of :class:`ckbytelist`.
           You can easly convert it to a binary string with:
@@ -1490,7 +1490,7 @@ class Session:
           (use `MechanismRSAPKCS1` for `CKM_RSA_PKCS`)
         :type mecha: :class:`Mechanism`
         :return: the wrapped key bytes
-        :rtype: list of bytes
+        :rtype: ckbytelist
 
         :note: the returned value is an instance of :class:`ckbytelist`.
           You can easily convert it to a binary string with:


### PR DESCRIPTION
The current version specifies "list of bytes" as return type, but it really is ckbytelist instead: this causes the type checker and the IDE to complain about wrong types all the time.

```python
mechanism = Mechanism(CKM_AES_ECB)
wrapped_key: ckbytelist = session.wrapKey(handle_of_wrapping_key, handle_of_key_to_be_wrapped, mechanism)
```
PyCharm complains:
```text
Expected type 'ckbytelist', got 'list[bytes]' instead 
```

This commit solves the issue in question.