### PR TITLE
Fix swig 4.5.0+ and python 3.12+ compatibility and add Linux wheel build CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -13,6 +13,9 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     # Steps represent a sequence of tasks that will be executed as part of
     # the job
@@ -21,9 +24,16 @@ jobs:
       # can access it
       - uses: actions/checkout@v7
 
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+
       - name: setup prerequisites (linux)
         shell: bash
-        run: sudo apt install python3-all-dev python3-setuptools softhsm2 swig tox
+        run: |
+          sudo apt install softhsm2 swig
+          pip install tox
 
       - name: Build
         run: |
@@ -53,7 +63,8 @@ jobs:
         shell: bash
         run: |
           ./get_PYKCS11LIB.py > tox.env
-          tox -e py312
+          ENV_NAME="py$(echo ${{ matrix.python-version }} | tr -d '.')"
+          tox -e $ENV_NAME
 
       - name: coverage
         shell: bash
@@ -67,3 +78,46 @@ jobs:
         uses: AndreMiras/coveralls-python-action@develop
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  build_wheels:
+    name: Build wheels on Linux
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install swig
+        run: sudo apt-get update && sudo apt-get install -y swig
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.21.3
+        env:
+          CIBW_BEFORE_BUILD: "yum install -y swig || apk add swig || apt-get install -y swig"
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: cibw-wheels-linux
+          path: ./wheelhouse/*.whl
+
+  publish:
+    name: "PyPI Publish"
+    needs: ["build", "build_wheels"]
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+    runs-on: "ubuntu-latest"
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pyscard
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
+
+      - name: move wheels to dist/
+        run: |
+          mkdir -v dist
+          mv -v cibw-wheels-linux/*.whl dist/
+          ls -al dist/
+
+      - name: Publish wheels to PyPI
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.12', '3.13', '3.14']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v7

--- a/src/pykcs11.i
+++ b/src/pykcs11.i
@@ -63,7 +63,7 @@ using namespace std;
 }
 
 %typemap(out) CK_RV {
-   $result = PyInt_FromLong((long)$1);
+   $result = PyLong_FromLong((long)$1);
 }
 
 #else

--- a/tox.ini
+++ b/tox.ini
@@ -8,16 +8,16 @@ envlist =
     pylint
     build
     coverage_erase
-    py{3.9, 3.10, 3.11, 3.12, 3.13}
+    py{3.9, 3.10, 3.11, 3.12, 3.13, 3.14}
     coverage_report
 skip_missing_interpreters = True
 labels =
-    build=build-py{3.9, 3.10, 3.11, 3.12, 3.13}
+    build=build-py{3.9, 3.10, 3.11, 3.12, 3.13, 3.14}
 
 [testenv]
 description = run the tests with pytest
 depends =
-    py{3.9, 3.10, 3.11, 3.12, 3.13}: coverage_erase
+    py{3.9, 3.10, 3.11, 3.12, 3.13, 3.14}: coverage_erase
 deps =
     pytest>=6
     -r{toxinidir}/dev-requirements.txt
@@ -43,7 +43,7 @@ commands =
     - coverage erase
 
 [testenv:coverage_report{,-ci}]
-depends = py{3.9, 3.10, 3.11, 3.12, 3.13}
+depends = py{3.9, 3.10, 3.11, 3.12, 3.13, 3.14}
 description =
     !ci: Generate HTML and console reports
     ci: Generate an XML report


### PR DESCRIPTION
### **Description:**
This PR addresses Python 3.13 and 3.14 compatibility by replacing the removed `PyInt_FromLong` API with `PyLong_FromLong`. It also updates the CI configuration to ensure Python 3.13 and 3.14 are officially supported and tested.

Closes #167.

### **Changes Proposed:**
1. **Source Code:**
   * Replaced `PyInt_FromLong` with `PyLong_FromLong` directly in `src/pykcs11.i` for standard Python 3 C API compatibility.
2. **CI / Test Pipelines:**
   * Added `py314` target to `tox.ini` environment lists.
   * Updated the Matrix strategy in `.github/workflows/linux.yml` and `.github/workflows/macos.yml` to test python versions from `3.9` up to `3.14` (matching `windows.yml`).
   * Added Linux wheels build (`build_wheels` job using `cibuildwheel`) and release uploading (`publish` job) to `.github/workflows/linux.yml`, so that precompiled `manylinux` wheels are built and uploaded to PyPI on tag release.

### **Verification Checklist:**
* [x] Verified compilation succeeds under Python 3.14 locally (which previously failed due to `PyInt_FromLong`).
* [x] Ran the local test suite using SoftHSM2 under Python 3.14, and all 88 unit tests successfully passed (`OK (skipped=8)`).
* [x] Inspected and checked YAML workflow formatting.
