### PR TITLE
Support Python 3.14, Free-Threaded 3.13t/3.14t, and Linux wheel compilation

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -13,6 +13,9 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.12', '3.13', '3.14']
 
     # Steps represent a sequence of tasks that will be executed as part of
     # the job
@@ -21,15 +24,24 @@ jobs:
       # can access it
       - uses: actions/checkout@v7
 
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+
       - name: setup prerequisites (linux)
         shell: bash
-        run: sudo apt install python3-all-dev python3-setuptools softhsm2 swig tox
+        run: |
+          sudo apt update
+          sudo apt install -y softhsm2 swig
+          python -m pip install --upgrade pip
+          pip install tox
 
       - name: Build
         run: |
-          python3 -m venv temp
+          python -m venv temp
           source temp/bin/activate
-          pip3 install -r dev-requirements.txt
+          pip install -r dev-requirements.txt
           make
 
       - name: Test
@@ -53,7 +65,8 @@ jobs:
         shell: bash
         run: |
           ./get_PYKCS11LIB.py > tox.env
-          tox -e py312
+          TOX_ENV="py$(echo ${{ matrix.python-version }} | tr -d '.')"
+          tox -e $TOX_ENV
 
       - name: coverage
         shell: bash
@@ -67,3 +80,48 @@ jobs:
         uses: AndreMiras/coveralls-python-action@develop
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  build_wheels:
+    name: Build wheels on Linux
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install swig
+        run: sudo apt-get update && sudo apt-get install -y swig
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.21.3
+        env:
+          CIBW_BEFORE_BUILD: "yum install -y swig || apk add swig || apt-get install -y swig"
+          CIBW_PRERELEASE_PYTHONS: "True"
+          CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-* cp313t-* cp314-* cp314t-*"
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: cibw-wheels-linux
+          path: ./wheelhouse/*.whl
+
+  publish:
+    name: "PyPI Publish"
+    needs: ["build", "build_wheels"]
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+    runs-on: "ubuntu-latest"
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pykcs11
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
+
+      - name: move wheels to dist/
+        run: |
+          mkdir -v dist
+          mv -v cibw-wheels-linux/*.whl dist/
+          ls -al dist/
+
+      - name: Publish wheels to PyPI
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2

--- a/src/PyKCS11/__init__.py
+++ b/src/PyKCS11/__init__.py
@@ -1088,8 +1088,8 @@ class EXTRACT_KEY_FROM_KEY_Mechanism:
     def __init__(self, extractParams):
         """
         :param extractParams: the index of the first bit of the original
-        key to be used in the newly-derived key.  For example if
-        extractParams=5 then the 5 first bits are skipped and not used.
+         key to be used in the newly-derived key.  For example if
+         extractParams=5 then the 5 first bits are skipped and not used.
         """
         self._param = PyKCS11.LowLevel.CK_EXTRACT_PARAMS()
         self._param.assign(extractParams)
@@ -1111,8 +1111,8 @@ class EDDSA_Mechanism:
 
     def __init__(self, phFlag=None, contextData=None):
         """
-        :param phFlag: prehash flag [True|False]. If this parameter is not set,
-        Ed25519 in pure mode without context is assumed.
+        :param phFlag: prehash flag [True|False]. If this parameter is not
+         set, Ed25519 in pure mode without context is assumed.
         :param context: context data (optional)
         """
         self._param = PyKCS11.LowLevel.CK_EDDSA_PARAMS()

--- a/test/test_symetric.py
+++ b/test/test_symetric.py
@@ -2,13 +2,14 @@
 # pylint: disable=missing-class-docstring
 # pylint: disable=missing-function-docstring
 
-import unittest
 import logging
+import unittest
 
 from PyKCS11 import PyKCS11
 
-test_logger = logging.getLogger('test_logger')
+test_logger = logging.getLogger("test_logger")
 test_logger.setLevel(logging.DEBUG)
+
 
 class TestUtil(unittest.TestCase):
     def setUp(self):

--- a/tox.ini
+++ b/tox.ini
@@ -8,16 +8,16 @@ envlist =
     pylint
     build
     coverage_erase
-    py{3.9, 3.10, 3.11, 3.12, 3.13}
+    py{3.9, 3.10, 3.11, 3.12, 3.13, 3.14, 3.13t, 3.14t}
     coverage_report
 skip_missing_interpreters = True
 labels =
-    build=build-py{3.9, 3.10, 3.11, 3.12, 3.13}
+    build=build-py{3.9, 3.10, 3.11, 3.12, 3.13, 3.14, 3.13t, 3.14t}
 
 [testenv]
 description = run the tests with pytest
 depends =
-    py{3.9, 3.10, 3.11, 3.12, 3.13}: coverage_erase
+    py{3.9, 3.10, 3.11, 3.12, 3.13, 3.14, 3.13t, 3.14t}: coverage_erase
 deps =
     pytest>=6
     -r{toxinidir}/dev-requirements.txt
@@ -25,6 +25,12 @@ setenv =
     file|tox.env
 commands =
     coverage run -m pytest {tty:--color=yes} {posargs}
+
+[testenv:py313t]
+basepython = python3.13t
+
+[testenv:py314t]
+basepython = python3.14t
 
 [testenv:build]
 description = Build sdist and wheel files
@@ -43,7 +49,7 @@ commands =
     - coverage erase
 
 [testenv:coverage_report{,-ci}]
-depends = py{3.9, 3.10, 3.11, 3.12, 3.13}
+depends = py{3.9, 3.10, 3.11, 3.12, 3.13, 3.14, 3.13t, 3.14t}
 description =
     !ci: Generate HTML and console reports
     ci: Generate an XML report


### PR DESCRIPTION
This PR adds CI support for Python 3.14 and free-threaded Python 3.13t and 3.14t, along with a Linux wheel building job to produce wheels for PyPI.

### Changes Included:
1. **Python 3.14 & Free-threaded Support**:
   - Updated tox.ini with configurations for py314, py313t, and py314t. Explicitly mapped basepython = python3.13t and basepython = python3.14t.
   - Updated test matrices in linux.yml to run the active test matrix on newer Python releases.
2. **Linux Wheel Packaging**:
   - Added a build_wheels job in linux.yml using cibuildwheel to compile standard and free-threaded Linux wheels.
   - Added a publish job to publish Linux wheels on release tags, aligning with the existing Windows and macOS pipelines (which also publish wheels only, while the source distribution sdist is left to be uploaded manually).