### PR TITLE
ci: build and publish source distribution (sdist) to PyPI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -98,9 +98,31 @@ jobs:
           name: cibw-wheels-linux
           path: ./wheelhouse/*.whl
 
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+
+      - name: Install build
+        run: python -m pip install --upgrade pip build
+
+      - name: Build sdist
+        run: python -m build --sdist
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: cibw-sdist
+          path: dist/*.tar.gz
+
   publish:
     name: "PyPI Publish"
-    needs: ["build", "build_wheels"]
+    needs: ["build", "build_wheels", "build_sdist"]
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     runs-on: "ubuntu-latest"
     environment:
@@ -113,11 +135,12 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
 
-      - name: move wheels to dist/
+      - name: move wheels and sdist to dist/
         run: |
           mkdir -v dist
           mv -v cibw-wheels-linux/*.whl dist/
+          mv -v cibw-sdist/*.tar.gz dist/
           ls -al dist/
 
-      - name: Publish wheels to PyPI
+      - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2


### PR DESCRIPTION
This PR automates building and publishing the source distribution (sdist) to PyPI alongside the precompiled wheels whenever a release tag is pushed.

It adds a new job build_sdist to linux.yml to build the .tar.gz using the Python build module, uploads it as an artifact, and updates the publish job to upload it together with the Linux wheels.