### PR TITLE
ci: bump cibuildwheel to v4.2.0 and update free-threading config

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -88,10 +88,9 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.21.3
+        uses: pypa/cibuildwheel@v4.2.0
         env:
-          CIBW_PRERELEASE_PYTHONS: "True"
-          CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-* cp313t-* cp314-* cp314t-*"
+          CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-* cp314-* cp314t-*"
 
       - uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
Bumps cibuildwheel from 2.21.3 to 4.2.0 and updates the build configuration for 4.x compatibility.

- Updates cibuildwheel action to v4.2.0.
- Removes cp313t-* from CIBW_BUILD as cibuildwheel 4.x removed experimental Python 3.13 free-threading support (pypa/cibuildwheel#2684).
- Retains cp314t-* for Python 3.14+ free-threading (supported natively in cibuildwheel 4.x without extra enable flags).
- Removes obsolete CIBW_PRERELEASE_PYTHONS setting.

supersedes #172.