### PR TITLE
build: replace deprecated license classifier with SPDX expression

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ The wrapper has been generated with the help of the SWIG compiler."""
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: GNU General Public License (GPL)",
     "Natural Language :: English",
     "Operating System :: Microsoft :: Windows",
     "Operating System :: OS Independent",
@@ -85,7 +84,7 @@ setup(
     maintainer_email="ludovic.rousseau@free.fr",
     url="https://github.com/LudovicRousseau/PyKCS11",
     download_url="http://sourceforge.net/projects/pkcs11wrap/files/pykcs11/",
-    license="GPL",
+    license="GPL-2.0-or-later",
     cmdclass={"build_py": MyBuild},
     package_dir={"": "src"},
     ext_modules=[


### PR DESCRIPTION
Per [PEP 639](https://peps.python.org/pep-0639/) and [pypa/trove-classifiers#236](https://github.com/pypa/trove-classifiers/issues/236), license classifiers are being deprecated across the Python packaging ecosystem in favor of SPDX expressions.

Recent versions of setuptools emit the following deprecation warning during wheel builds:
> `SetuptoolsDeprecationWarning: License classifiers are deprecated. Please consider removing the following classifiers in favor of a SPDX license expression: License :: OSI Approved :: GNU General Public License (GPL)`

### Changes:
- Removed `License :: OSI Approved :: GNU General Public License (GPL)` from `classifiers` in `setup.py`.
- Set `license="GPL-2.0-or-later"` in `setup()` according to the SPDX standard and the project's GPLv2+ license headers.

Opening as a Draft PR for review. Let me know if you would like to proceed with this and I can mark it ready for review!